### PR TITLE
feat: add pagination

### DIFF
--- a/pkg/api/handler_holds_list.go
+++ b/pkg/api/handler_holds_list.go
@@ -3,15 +3,24 @@ package api
 import (
 	"net/http"
 
+	"github.com/formancehq/wallets/pkg/wallet"
 	"github.com/go-chi/chi/v5"
 )
 
 func (m *MainHandler) ListHoldsHandler(w http.ResponseWriter, r *http.Request) {
-	holds, err := m.repository.ListHolds(r.Context(), chi.URLParam(r, "wallet_id"))
+	query := wallet.ListQuery[wallet.ListHolds]{
+		Payload: wallet.ListHolds{
+			WalletID: chi.URLParam(r, "wallet_id"),
+		},
+		Limit:           parseLimit(r),
+		PaginationToken: parsePaginationToken(r),
+	}
+
+	holds, err := m.repository.ListHolds(r.Context(), query)
 	if err != nil {
 		internalError(w, r, err)
 		return
 	}
 
-	ok(w, holds)
+	cursorFromListResponse(w, query, holds)
 }

--- a/pkg/api/handler_holds_list_test.go
+++ b/pkg/api/handler_holds_list_test.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	sdk "github.com/formancehq/formance-sdk-go"
+	"github.com/formancehq/go-libs/sharedapi"
 	"github.com/formancehq/wallets/pkg/core"
+	"github.com/formancehq/wallets/pkg/wallet"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -17,38 +21,84 @@ func TestHoldsList(t *testing.T) {
 
 	walletID := uuid.NewString()
 
-	req := newRequest(t, http.MethodGet, "/wallets/"+walletID+"/holds", nil)
-	rec := httptest.NewRecorder()
-
 	holds := make([]core.DebitHold, 0)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		holds = append(holds, core.NewDebitHold(walletID, "bank", "USD"))
 	}
+	const pageSize = 2
+	numberOfPages := int64(len(holds) / pageSize)
 
 	var testEnv *testEnv
 	testEnv = newTestEnv(
-		WithListAccountsWithMetadata(func(ctx context.Context, name string, m map[string]any) ([]sdk.Account, error) {
-			require.Equal(t, testEnv.LedgerName(), name)
+		WithListAccounts(func(ctx context.Context, ledger string, query wallet.ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error) {
+			if query.PaginationToken != "" {
+				page, err := strconv.ParseInt(query.PaginationToken, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+
+				if page >= numberOfPages-1 {
+					return &sdk.ListAccounts200ResponseCursor{}, nil
+				}
+				hasMore := page < numberOfPages-1
+				previous := fmt.Sprint(page - 1)
+				next := fmt.Sprint(page + 1)
+				accounts := make([]sdk.Account, 0)
+				for _, hold := range holds[page*pageSize : (page+1)*pageSize] {
+					accounts = append(accounts, sdk.Account{
+						Address:  testEnv.Chart().GetMainAccount(hold.ID),
+						Metadata: hold.LedgerMetadata(testEnv.Chart()),
+					})
+				}
+				return &sdk.ListAccounts200ResponseCursor{
+					PageSize: pageSize,
+					HasMore:  &hasMore,
+					Previous: &previous,
+					Next:     &next,
+					Data:     accounts,
+				}, nil
+			}
+
+			require.Equal(t, pageSize, query.Limit)
+			require.Equal(t, testEnv.LedgerName(), ledger)
 			require.EqualValues(t, core.Metadata{
 				core.MetadataKeySpecType:     core.HoldWallet,
 				core.MetadataKeyHoldWalletID: walletID,
-			}, m)
-			ret := make([]sdk.Account, 0)
-			for _, hold := range holds {
-				ret = append(ret, sdk.Account{
-					Address:  testEnv.Chart().GetHoldAccount(hold.ID),
-					Metadata: hold.LedgerMetadata(testEnv.Chart()),
+			}, query.Metadata)
+
+			hasMore := true
+			next := "1"
+			accounts := make([]sdk.Account, 0)
+			for _, wallet := range holds[:pageSize] {
+				accounts = append(accounts, sdk.Account{
+					Address:  testEnv.Chart().GetMainAccount(wallet.ID),
+					Metadata: wallet.LedgerMetadata(testEnv.Chart()),
 				})
 			}
-			return ret, nil
+			return &sdk.ListAccounts200ResponseCursor{
+				PageSize: pageSize,
+				HasMore:  &hasMore,
+				Next:     &next,
+				Data:     accounts,
+			}, nil
 		}),
 	)
+	req := newRequest(t, http.MethodGet, fmt.Sprintf("/wallets/%s/holds?limit=%d", walletID, pageSize), nil)
+	rec := httptest.NewRecorder()
 	testEnv.Router().ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	cursor := &sharedapi.Cursor[core.DebitHold]{}
+	readCursor(t, rec, cursor)
+	require.Len(t, cursor.Data, pageSize)
+	require.EqualValues(t, holds[:pageSize], cursor.Data)
 
-	list := make([]core.DebitHold, 0)
-	readResponse(t, rec, &list)
-	require.Len(t, list, 3)
-	require.EqualValues(t, holds, list)
+	req = newRequest(t, http.MethodGet, fmt.Sprintf("/wallets/%s/holds?cursor=%s", walletID, cursor.Next), nil)
+	rec = httptest.NewRecorder()
+	testEnv.Router().ServeHTTP(rec, req)
+
+	cursor = &sharedapi.Cursor[core.DebitHold]{}
+	readCursor(t, rec, cursor)
+	require.Len(t, cursor.Data, pageSize)
+	require.EqualValues(t, holds[pageSize:pageSize*2], cursor.Data)
 }

--- a/pkg/api/handler_holds_void_test.go
+++ b/pkg/api/handler_holds_void_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	sdk "github.com/formancehq/formance-sdk-go"
 	"github.com/formancehq/wallets/pkg/core"
 	"github.com/formancehq/wallets/pkg/wallet/numscript"
@@ -29,7 +28,7 @@ func TestHoldsVoid(t *testing.T) {
 		WithGetAccount(func(ctx context.Context, ledger, account string) (*sdk.AccountWithVolumesAndBalances, error) {
 			require.Equal(t, testEnv.LedgerName(), ledger)
 			require.Equal(t, testEnv.Chart().GetHoldAccount(hold.ID), account)
-			spew.Dump(hold.LedgerMetadata(testEnv.Chart()))
+
 			return &sdk.AccountWithVolumesAndBalances{
 				Address:  testEnv.Chart().GetHoldAccount(hold.ID),
 				Metadata: hold.LedgerMetadata(testEnv.Chart()),

--- a/pkg/api/handler_wallets_list.go
+++ b/pkg/api/handler_wallets_list.go
@@ -2,14 +2,20 @@ package api
 
 import (
 	"net/http"
+
+	"github.com/formancehq/wallets/pkg/wallet"
 )
 
 func (m *MainHandler) ListWalletsHandler(w http.ResponseWriter, r *http.Request) {
-	wallets, err := m.repository.ListWallets(r.Context())
+	query := wallet.ListQuery[struct{}]{
+		Limit:           parseLimit(r),
+		PaginationToken: parsePaginationToken(r),
+	}
+	response, err := m.repository.ListWallets(r.Context(), query)
 	if err != nil {
 		internalError(w, r, err)
 		return
 	}
 
-	ok(w, wallets)
+	cursorFromListResponse(w, query, response)
 }

--- a/pkg/api/handler_wallets_list_test.go
+++ b/pkg/api/handler_wallets_list_test.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	sdk "github.com/formancehq/formance-sdk-go"
+	"github.com/formancehq/go-libs/sharedapi"
 	"github.com/formancehq/wallets/pkg/core"
+	"github.com/formancehq/wallets/pkg/wallet"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -15,36 +19,83 @@ import (
 func TestWalletsList(t *testing.T) {
 	t.Parallel()
 
-	req := newRequest(t, http.MethodGet, "/wallets", nil)
-	rec := httptest.NewRecorder()
-
 	var wallets []core.Wallet
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		wallets = append(wallets, core.NewWallet(uuid.NewString(), core.Metadata{}))
 	}
+	const pageSize = 2
+	numberOfPages := int64(len(wallets) / pageSize)
 
 	var testEnv *testEnv
 	testEnv = newTestEnv(
-		WithListAccountsWithMetadata(func(ctx context.Context, name string, m map[string]any) ([]sdk.Account, error) {
-			require.Equal(t, testEnv.LedgerName(), name)
+		WithListAccounts(func(ctx context.Context, ledger string, query wallet.ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error) {
+			if query.PaginationToken != "" {
+				page, err := strconv.ParseInt(query.PaginationToken, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+
+				if page >= numberOfPages-1 {
+					return &sdk.ListAccounts200ResponseCursor{}, nil
+				}
+				hasMore := page < numberOfPages-1
+				previous := fmt.Sprint(page - 1)
+				next := fmt.Sprint(page + 1)
+				accounts := make([]sdk.Account, 0)
+				for _, wallet := range wallets[page*pageSize : (page+1)*pageSize] {
+					accounts = append(accounts, sdk.Account{
+						Address:  testEnv.Chart().GetMainAccount(wallet.ID),
+						Metadata: wallet.LedgerMetadata(),
+					})
+				}
+				return &sdk.ListAccounts200ResponseCursor{
+					PageSize: pageSize,
+					HasMore:  &hasMore,
+					Previous: &previous,
+					Next:     &next,
+					Data:     accounts,
+				}, nil
+			}
+
+			require.Equal(t, pageSize, query.Limit)
+			require.Equal(t, testEnv.LedgerName(), ledger)
 			require.Equal(t, map[string]any{
 				core.MetadataKeySpecType: core.PrimaryWallet,
-			}, m)
-			ret := make([]sdk.Account, 0)
-			for _, wallet := range wallets {
-				ret = append(ret, sdk.Account{
+			}, query.Metadata)
+
+			hasMore := true
+			next := "1"
+			accounts := make([]sdk.Account, 0)
+			for _, wallet := range wallets[:pageSize] {
+				accounts = append(accounts, sdk.Account{
 					Address:  testEnv.Chart().GetMainAccount(wallet.ID),
 					Metadata: wallet.LedgerMetadata(),
 				})
 			}
-			return ret, nil
+			return &sdk.ListAccounts200ResponseCursor{
+				PageSize: pageSize,
+				HasMore:  &hasMore,
+				Next:     &next,
+				Data:     accounts,
+			}, nil
 		}),
 	)
+
+	req := newRequest(t, http.MethodGet, fmt.Sprintf("/wallets?limit=%d", pageSize), nil)
+	rec := httptest.NewRecorder()
 	testEnv.Router().ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
-	list := make([]core.Wallet, 0)
-	readResponse(t, rec, &list)
-	require.Len(t, list, len(wallets))
-	require.EqualValues(t, list, wallets)
+	cursor := &sharedapi.Cursor[core.Wallet]{}
+	readCursor(t, rec, cursor)
+	require.Len(t, cursor.Data, pageSize)
+	require.EqualValues(t, cursor.Data, wallets[:pageSize])
+
+	req = newRequest(t, http.MethodGet, fmt.Sprintf("/wallets?cursor=%s", cursor.Next), nil)
+	rec = httptest.NewRecorder()
+	testEnv.Router().ServeHTTP(rec, req)
+	cursor = &sharedapi.Cursor[core.Wallet]{}
+	readCursor(t, rec, cursor)
+	require.Len(t, cursor.Data, pageSize)
+	require.EqualValues(t, cursor.Data, wallets[pageSize:pageSize*2])
 }

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/formancehq/go-libs/sharedapi"
 	"github.com/formancehq/go-libs/sharedlogging"
+	"github.com/formancehq/wallets/pkg/wallet"
 )
 
 func notFound(w http.ResponseWriter) {
@@ -50,4 +52,41 @@ func ok(w io.Writer, v any) {
 	}); err != nil {
 		panic(err)
 	}
+}
+
+func cursor[T any](w io.Writer, v sharedapi.Cursor[T]) {
+	if err := json.NewEncoder(w).Encode(sharedapi.BaseResponse[T]{
+		Cursor: &v,
+	}); err != nil {
+		panic(err)
+	}
+}
+
+func cursorFromListResponse[T any, V any](w io.Writer, query wallet.ListQuery[V], response *wallet.ListResponse[T]) {
+	cursor(w, sharedapi.Cursor[T]{
+		PageSize: query.Limit,
+		HasMore:  response.HasMore,
+		Previous: response.Previous,
+		Next:     response.Next,
+		Data:     response.Data,
+	})
+}
+
+func parsePaginationToken(r *http.Request) string {
+	return r.URL.Query().Get("cursor")
+}
+
+const defaultLimit = 15
+
+func parseLimit(r *http.Request) int {
+	limit := r.URL.Query().Get("limit")
+	if limit == "" {
+		return defaultLimit
+	}
+
+	v, err := strconv.ParseInt(limit, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	return int(v)
 }


### PR DESCRIPTION
# Pagination

Add pagination on GET /wallets and GET /wallets/<id>/holds

Default page size : 15
Define limit using query parameter "limit" and use next/previous tokens using "cursor" parameter (as already defined).