### PR TITLE
feat: Add GET /transactions

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -5,12 +5,51 @@ info:
   version: 0.1.0
 
 paths:
+  /transactions:
+    get:
+      operationId: getTransactions
+      parameters:
+      - name: limit
+        in: query
+        description: 'The maximum number of results to return per page'
+        example: 100
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 15
+      - name: wallet_id
+        in: query
+        description: "A wallet ID to filter on"
+        example: "wallet1"
+        schema:
+          type: string
+      - name: cursor
+        in: query
+        description: |
+          Parameter used in pagination requests.
+          Set to the value of next for the next page of results.
+          Set to the value of previous for the previous page of results.
+          No other parameters can be set when the cursor is set.
+        schema:
+          type: string
+          example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
+      tags:
+      - Wallets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionsResponse'
+
   /wallets:
     get:
       summary: Get all wallets
       operationId: getWallets
       parameters:
-      - name: page_size
+      - name: limit
         in: query
         description: 'The maximum number of results to return per page'
         example: 100
@@ -25,10 +64,10 @@ paths:
         schema:
           type: string
           example: users:003
-      - name: pagination_token
+      - name: cursor
         in: query
         description: |
-          Parameter used in pagination requests. Maximum page size is set to 15.
+          Parameter used in pagination requests.
           Set to the value of next for the next page of results.
           Set to the value of previous for the previous page of results.
           No other parameters can be set when the pagination token is set.
@@ -184,6 +223,26 @@ paths:
       tags:
         - Wallets
       operationId: getHolds
+      parameters:
+      - name: limit
+        in: query
+        description: 'The maximum number of results to return per page'
+        example: 100
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          default: 15
+      - name: cursor
+        in: query
+        description: |
+          Parameter used in pagination requests.
+          Set to the value of next for the next page of results.
+          Set to the value of previous for the previous page of results.
+          No other parameters can be set when the pagination token is set.
+        schema:
+          type: string
+          example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
       responses:
         200:
           description: Holds
@@ -304,12 +363,19 @@ components:
     GetWalletsResponse:
       type: object
       required:
-      - data
+      - cursor
       properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/Wallet'
+        cursor:
+          allOf:
+          - $ref: '#/components/schemas/Cursor'
+          - properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Wallet'
+                type: array
+            type: object
+            required:
+            - data
     CreateWalletResponse:
       type: object
       required:
@@ -331,15 +397,118 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/Hold'
+    AggregatedVolumes:
+      type: object
+      x-go-type:
+        type: AggregatedVolumes
+      additionalProperties:
+        $ref: '#/components/schemas/Volumes'
+    Metadata:
+      type: object
+      nullable: true
+      additionalProperties: {}
+      example: { admin: true, a: { nested: { key: value } } }
+    Posting:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: int64
+          minimum: 0
+          example: 100
+        asset:
+          type: string
+          example: COIN
+        destination:
+          type: string
+          example: users:002
+        source:
+          type: string
+          example: users:001
+      required:
+      - amount
+      - asset
+      - destination
+      - source
+    Transaction:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        postings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Posting'
+        reference:
+          type: string
+          example: ref:001
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        txid:
+          type: integer
+          format: int64
+          minimum: 0
+        preCommitVolumes:
+          $ref: '#/components/schemas/AggregatedVolumes'
+        postCommitVolumes:
+          $ref: '#/components/schemas/AggregatedVolumes'
+      required:
+      - postings
+      - timestamp
+      - txid
+    Cursor:
+      type: object
+      required:
+      - page_size
+      properties:
+        page_size:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 1000
+          example: 15
+        has_more:
+          type: boolean
+          example: false
+        previous:
+          type: string
+          example: "YXVsdCBhbmQgYSBtYXhpbXVtIG1heF9yZXN1bHRzLol="
+        next:
+          type: string
+          example: ""
+    GetTransactionsResponse:
+      type: object
+      required:
+      - cursor
+      properties:
+        cursor:
+          allOf:
+          - $ref: '#/components/schemas/Cursor'
+          - properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Transaction'
+                type: array
+            type: object
+            required:
+            - data
     GetHoldsResponse:
       type: object
       required:
-      - data
+      - cursor
       properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/Hold'
+        cursor:
+          allOf:
+          - $ref: '#/components/schemas/Cursor'
+          - properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Hold'
+                type: array
+            type: object
+            required:
+            - data
     CreateWalletRequest:
       type: object
       required:
@@ -351,3 +520,33 @@ components:
           additionalProperties: {}
         name:
           type: string
+    Volume:
+      type: object
+      properties:
+        input:
+          type: number
+        output:
+          type: number
+        balance:
+          type: number
+      required:
+      - input
+      - output
+      - balance
+      example:
+        input: 100
+        output: 20
+        balance: 80
+    Volumes:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Volume'
+      example:
+        USD:
+          input: 100
+          output: 10
+          balance: 90
+        EUR:
+          input: 100
+          output: 10
+          balance: 90

--- a/pkg/api/handler_holds_confirm_test.go
+++ b/pkg/api/handler_holds_confirm_test.go
@@ -43,6 +43,7 @@ func TestHoldsConfirm(t *testing.T) {
 				Vars: map[string]interface{}{
 					"hold": testEnv.Chart().GetHoldAccount(hold.ID),
 				},
+				Metadata: core.WalletTransactionBaseMetadata(),
 			}, script)
 			return nil
 		}),

--- a/pkg/api/handler_holds_list.go
+++ b/pkg/api/handler_holds_list.go
@@ -8,13 +8,11 @@ import (
 )
 
 func (m *MainHandler) ListHoldsHandler(w http.ResponseWriter, r *http.Request) {
-	query := wallet.ListQuery[wallet.ListHolds]{
-		Payload: wallet.ListHolds{
+	query := readPaginatedRequest(r, func(r *http.Request) wallet.ListHolds {
+		return wallet.ListHolds{
 			WalletID: chi.URLParam(r, "wallet_id"),
-		},
-		Limit:           parseLimit(r),
-		PaginationToken: parsePaginationToken(r),
-	}
+		}
+	})
 
 	holds, err := m.repository.ListHolds(r.Context(), query)
 	if err != nil {

--- a/pkg/api/handler_holds_list_test.go
+++ b/pkg/api/handler_holds_list_test.go
@@ -30,7 +30,7 @@ func TestHoldsList(t *testing.T) {
 
 	var testEnv *testEnv
 	testEnv = newTestEnv(
-		WithListAccounts(func(ctx context.Context, ledger string, query wallet.ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error) {
+		WithListAccounts(func(ctx context.Context, ledger string, query wallet.ListAccountsQuery) (*sdk.ListAccounts200ResponseCursor, error) {
 			if query.PaginationToken != "" {
 				page, err := strconv.ParseInt(query.PaginationToken, 10, 64)
 				if err != nil {

--- a/pkg/api/handler_holds_void_test.go
+++ b/pkg/api/handler_holds_void_test.go
@@ -40,6 +40,7 @@ func TestHoldsVoid(t *testing.T) {
 				Vars: map[string]interface{}{
 					"hold": testEnv.Chart().GetHoldAccount(hold.ID),
 				},
+				Metadata: core.WalletTransactionBaseMetadata(),
 			}, script)
 			return nil
 		}),

--- a/pkg/api/handler_transactions_list.go
+++ b/pkg/api/handler_transactions_list.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/formancehq/wallets/pkg/wallet"
+)
+
+func (m *MainHandler) ListTransactions(w http.ResponseWriter, r *http.Request) {
+	query := readPaginatedRequest[wallet.ListTransactions](r, func(r *http.Request) wallet.ListTransactions {
+		return wallet.ListTransactions{
+			WalletID: r.URL.Query().Get("wallet_id"),
+		}
+	})
+	transactions, err := m.repository.ListTransactions(r.Context(), query)
+	if err != nil {
+		internalError(w, r, err)
+		return
+	}
+
+	cursorFromListResponse(w, query, transactions)
+}

--- a/pkg/api/handler_transactions_list_test.go
+++ b/pkg/api/handler_transactions_list_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	sdk "github.com/formancehq/formance-sdk-go"
+	"github.com/formancehq/go-libs/sharedapi"
+	"github.com/formancehq/wallets/pkg/core"
+	"github.com/formancehq/wallets/pkg/wallet"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionsList(t *testing.T) {
+	t.Parallel()
+
+	w := core.NewWallet(uuid.NewString(), core.Metadata{})
+
+	var transactions []sdk.Transaction
+	for i := 0; i < 10; i++ {
+		transactions = append(transactions, sdk.Transaction{
+			Postings: []sdk.Posting{{
+				Amount:      100,
+				Asset:       "USD/2",
+				Destination: "bank",
+				Source:      "world",
+			}},
+		})
+	}
+	const pageSize = 2
+	numberOfPages := int64(len(transactions) / pageSize)
+
+	var testEnv *testEnv
+	testEnv = newTestEnv(
+		WithListTransactions(func(ctx context.Context, ledger string, query wallet.ListTransactionsQuery) (*sdk.ListTransactions200ResponseCursor, error) {
+			if query.PaginationToken != "" {
+				page, err := strconv.ParseInt(query.PaginationToken, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+
+				if page >= numberOfPages-1 {
+					return &sdk.ListTransactions200ResponseCursor{}, nil
+				}
+				hasMore := page < numberOfPages-1
+				previous := fmt.Sprint(page - 1)
+				next := fmt.Sprint(page + 1)
+
+				return &sdk.ListTransactions200ResponseCursor{
+					PageSize: pageSize,
+					HasMore:  &hasMore,
+					Previous: &previous,
+					Next:     &next,
+					Data:     transactions[page*pageSize : (page+1)*pageSize],
+				}, nil
+			}
+
+			require.Equal(t, pageSize, query.Limit)
+			require.Equal(t, testEnv.LedgerName(), ledger)
+			require.Equal(t, testEnv.Chart().GetMainAccount(w.ID), query.Account)
+
+			hasMore := true
+			next := "1"
+
+			return &sdk.ListTransactions200ResponseCursor{
+				PageSize: pageSize,
+				HasMore:  &hasMore,
+				Next:     &next,
+				Data:     transactions[:pageSize],
+			}, nil
+		}),
+	)
+
+	req := newRequest(t, http.MethodGet, fmt.Sprintf("/transactions?limit=%d&wallet_id=%s", pageSize, w.ID), nil)
+	rec := httptest.NewRecorder()
+	testEnv.Router().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	cursor := &sharedapi.Cursor[sdk.Transaction]{}
+	readCursor(t, rec, cursor)
+	require.Len(t, cursor.Data, pageSize)
+	require.EqualValues(t, cursor.Data, transactions[:pageSize])
+
+	req = newRequest(t, http.MethodGet, fmt.Sprintf("/transactions?cursor=%s", cursor.Next), nil)
+	rec = httptest.NewRecorder()
+	testEnv.Router().ServeHTTP(rec, req)
+	cursor = &sharedapi.Cursor[sdk.Transaction]{}
+	readCursor(t, rec, cursor)
+	require.Len(t, cursor.Data, pageSize)
+	require.EqualValues(t, cursor.Data, transactions[pageSize:pageSize*2])
+}

--- a/pkg/api/handler_wallets_credit_test.go
+++ b/pkg/api/handler_wallets_credit_test.go
@@ -42,12 +42,12 @@ func TestWalletsCredit(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, rec.Result().StatusCode)
 	require.Equal(t, testEnv.LedgerName(), ledger)
 	require.Equal(t, sdk.TransactionData{
-		Timestamp: nil,
 		Postings: []sdk.Posting{{
 			Amount:      100,
 			Asset:       "USD",
 			Destination: testEnv.Chart().GetMainAccount(walletID),
 			Source:      "world",
 		}},
+		Metadata: core.WalletTransactionBaseMetadata(),
 	}, transactionData)
 }

--- a/pkg/api/handler_wallets_debit_test.go
+++ b/pkg/api/handler_wallets_debit_test.go
@@ -49,6 +49,7 @@ func TestWalletsDebit(t *testing.T) {
 			Source:      testEnv.Chart().GetMainAccount(walletID),
 			Destination: "world",
 		}},
+		Metadata: core.WalletTransactionBaseMetadata(),
 	}, transactionData)
 }
 
@@ -104,5 +105,6 @@ func TestWalletsDebitWithHold(t *testing.T) {
 			Source:      testEnv.Chart().GetMainAccount(walletID),
 			Destination: testEnv.Chart().GetHoldAccount(hold.ID),
 		}},
+		Metadata: core.WalletTransactionBaseMetadata(),
 	}, transactionData)
 }

--- a/pkg/api/handler_wallets_list.go
+++ b/pkg/api/handler_wallets_list.go
@@ -2,15 +2,10 @@ package api
 
 import (
 	"net/http"
-
-	"github.com/formancehq/wallets/pkg/wallet"
 )
 
 func (m *MainHandler) ListWalletsHandler(w http.ResponseWriter, r *http.Request) {
-	query := wallet.ListQuery[struct{}]{
-		Limit:           parseLimit(r),
-		PaginationToken: parsePaginationToken(r),
-	}
+	query := readPaginatedRequest[struct{}](r, nil)
 	response, err := m.repository.ListWallets(r.Context(), query)
 	if err != nil {
 		internalError(w, r, err)

--- a/pkg/api/handler_wallets_list_test.go
+++ b/pkg/api/handler_wallets_list_test.go
@@ -28,7 +28,7 @@ func TestWalletsList(t *testing.T) {
 
 	var testEnv *testEnv
 	testEnv = newTestEnv(
-		WithListAccounts(func(ctx context.Context, ledger string, query wallet.ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error) {
+		WithListAccounts(func(ctx context.Context, ledger string, query wallet.ListAccountsQuery) (*sdk.ListAccounts200ResponseCursor, error) {
 			if query.PaginationToken != "" {
 				page, err := strconv.ParseInt(query.PaginationToken, 10, 64)
 				if err != nil {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -48,6 +48,9 @@ func NewRouter(
 				})
 			})
 		})
+		r.Route("/transactions", func(r chi.Router) {
+			r.Get("/", main.ListTransactions)
+		})
 	})
 
 	return r

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -11,6 +11,8 @@ import (
 	"github.com/formancehq/wallets/pkg/wallet"
 )
 
+const defaultLimit = 15
+
 func notFound(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNotFound)
 }
@@ -76,8 +78,6 @@ func parsePaginationToken(r *http.Request) string {
 	return r.URL.Query().Get("cursor")
 }
 
-const defaultLimit = 15
-
 func parseLimit(r *http.Request) int {
 	limit := r.URL.Query().Get("limit")
 	if limit == "" {
@@ -89,4 +89,16 @@ func parseLimit(r *http.Request) int {
 		panic(err)
 	}
 	return int(v)
+}
+
+func readPaginatedRequest[T any](r *http.Request, f func(r *http.Request) T) wallet.ListQuery[T] {
+	var payload T
+	if f != nil {
+		payload = f(r)
+	}
+	return wallet.ListQuery[T]{
+		Limit:           parseLimit(r),
+		PaginationToken: parsePaginationToken(r),
+		Payload:         payload,
+	}
 }

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -84,7 +84,8 @@ func newTestEnv(opts ...Option) *testEnv {
 type (
 	addMetadataToAccountFn func(ctx context.Context, ledger, account string, metadata core.Metadata) error
 	getAccountFn           func(ctx context.Context, ledger, account string) (*sdk.AccountWithVolumesAndBalances, error)
-	listAccountsFn         func(ctx context.Context, ledger string, query wallet.ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error)
+	listAccountsFn         func(ctx context.Context, ledger string, query wallet.ListAccountsQuery) (*sdk.ListAccounts200ResponseCursor, error)
+	listTransactionsFn     func(ctx context.Context, ledger string, query wallet.ListTransactionsQuery) (*sdk.ListTransactions200ResponseCursor, error)
 	createTransactionFn    func(ctx context.Context, name string, transaction sdk.TransactionData) error
 	runScriptFn            func(ctx context.Context, name string, script sdk.Script) error
 )
@@ -93,6 +94,7 @@ type LedgerMock struct {
 	addMetadataToAccount addMetadataToAccountFn
 	getAccount           getAccountFn
 	listAccounts         listAccountsFn
+	listTransactions     listTransactionsFn
 	createTransaction    createTransactionFn
 	runScript            runScriptFn
 }
@@ -105,7 +107,7 @@ func (l *LedgerMock) GetAccount(ctx context.Context, ledger, account string) (*s
 	return l.getAccount(ctx, ledger, account)
 }
 
-func (l *LedgerMock) ListAccounts(ctx context.Context, ledger string, query wallet.ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error) {
+func (l *LedgerMock) ListAccounts(ctx context.Context, ledger string, query wallet.ListAccountsQuery) (*sdk.ListAccounts200ResponseCursor, error) {
 	return l.listAccounts(ctx, ledger, query)
 }
 
@@ -115,6 +117,10 @@ func (l *LedgerMock) CreateTransaction(ctx context.Context, name string, transac
 
 func (l *LedgerMock) RunScript(ctx context.Context, name string, script sdk.Script) error {
 	return l.runScript(ctx, name, script)
+}
+
+func (l *LedgerMock) ListTransactions(ctx context.Context, ledger string, query wallet.ListTransactionsQuery) (*sdk.ListTransactions200ResponseCursor, error) {
+	return l.listTransactions(ctx, ledger, query)
 }
 
 var _ wallet.Ledger = &LedgerMock{}
@@ -148,6 +154,12 @@ func WithCreateTransaction(fn createTransactionFn) Option {
 func WithListAccounts(fn listAccountsFn) Option {
 	return func(mock *LedgerMock) {
 		mock.listAccounts = fn
+	}
+}
+
+func WithListTransactions(fn listTransactionsFn) Option {
+	return func(mock *LedgerMock) {
+		mock.listTransactions = fn
 	}
 }
 

--- a/pkg/core/wallet.go
+++ b/pkg/core/wallet.go
@@ -5,17 +5,24 @@ import (
 )
 
 const (
-	MetadataKeySpecType         = "spec/type"
-	MetadataKeyWalletID         = "wallets/id"
-	MetadataKeyWalletName       = "wallets/name"
-	MetadataKeyWalletCustomData = "wallets/custom_data"
-	MetadataKeyHoldWalletID     = "holds/wallet_id"
-	MetadataKeyAsset            = "holds/asset"
-	MetadataKeyHoldID           = "holds/id"
+	MetadataKeyWalletTransaction = "wallets"
+	MetadataKeySpecType          = "spec/type"
+	MetadataKeyWalletID          = "wallets/id"
+	MetadataKeyWalletName        = "wallets/name"
+	MetadataKeyWalletCustomData  = "wallets/custom_data"
+	MetadataKeyHoldWalletID      = "holds/wallet_id"
+	MetadataKeyAsset             = "holds/asset"
+	MetadataKeyHoldID            = "holds/id"
 
 	PrimaryWallet = "wallets.primary"
 	HoldWallet    = "wallets.hold"
 )
+
+func WalletTransactionBaseMetadata() map[string]interface{} {
+	return map[string]interface{}{
+		MetadataKeyWalletTransaction: true,
+	}
+}
 
 type Wallet struct {
 	ID       string   `json:"id"`

--- a/pkg/wallet/funding.go
+++ b/pkg/wallet/funding.go
@@ -88,6 +88,7 @@ func (s *FundingService) Debit(ctx context.Context, debit Debit) (*core.DebitHol
 				Destination: dest,
 			},
 		},
+		Metadata: core.WalletTransactionBaseMetadata(),
 	}
 
 	if debit.Reference != "" {
@@ -132,6 +133,7 @@ func (s *FundingService) ConfirmHold(ctx context.Context, debit ConfirmHold) err
 			Vars: map[string]interface{}{
 				"hold": s.chart.GetHoldAccount(debit.HoldID),
 			},
+			Metadata: core.WalletTransactionBaseMetadata(),
 		},
 	); err != nil {
 		return errors.Wrap(err, "running script")
@@ -156,6 +158,7 @@ func (s *FundingService) VoidHold(ctx context.Context, void VoidHold) error {
 			Vars: map[string]interface{}{
 				"hold": s.chart.GetHoldAccount(void.HoldID),
 			},
+			Metadata: core.WalletTransactionBaseMetadata(),
 		},
 	); err != nil {
 		return errors.Wrap(err, "running script")
@@ -180,6 +183,7 @@ func (s *FundingService) Credit(ctx context.Context, credit Credit) error {
 				Destination: s.chart.GetMainAccount(credit.WalletID),
 			},
 		},
+		Metadata: core.WalletTransactionBaseMetadata(),
 	}
 
 	if credit.Reference != "" {

--- a/pkg/wallet/ledger_interface.go
+++ b/pkg/wallet/ledger_interface.go
@@ -7,22 +7,57 @@ import (
 	"github.com/formancehq/wallets/pkg/core"
 )
 
-type ListAccountQuery struct {
+type ListAccountsQuery struct {
 	PaginationToken string
 	Limit           int
 	Metadata        map[string]any
 }
 
+type ListTransactionsQuery struct {
+	PaginationToken string
+	Limit           int
+	Metadata        map[string]any
+	Destination     string
+	Source          string
+	Account         string
+}
+
 type Ledger interface {
 	AddMetadataToAccount(ctx context.Context, ledger, account string, metadata core.Metadata) error
 	GetAccount(ctx context.Context, ledger, account string) (*sdk.AccountWithVolumesAndBalances, error)
-	ListAccounts(ctx context.Context, ledger string, query ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error)
+	ListAccounts(ctx context.Context, ledger string, query ListAccountsQuery) (*sdk.ListAccounts200ResponseCursor, error)
+	ListTransactions(ctx context.Context, ledger string, query ListTransactionsQuery) (*sdk.ListTransactions200ResponseCursor, error)
 	CreateTransaction(ctx context.Context, ledger string, transaction sdk.TransactionData) error
 	RunScript(ctx context.Context, ledger string, script sdk.Script) error
 }
 
 type DefaultLedger struct {
 	client *sdk.APIClient
+}
+
+func (d DefaultLedger) ListTransactions(ctx context.Context, ledger string, query ListTransactionsQuery) (*sdk.ListTransactions200ResponseCursor, error) {
+	var (
+		ret *sdk.ListTransactions200Response
+		err error
+	)
+	if query.PaginationToken == "" {
+		ret, _, err = d.client.TransactionsApi.ListTransactions(ctx, ledger).
+			Metadata(query.Metadata).
+			PageSize(int32(query.Limit)).
+			Destination(query.Destination).
+			Account(query.Account).
+			Source(query.Source).
+			Execute()
+	} else {
+		ret, _, err = d.client.TransactionsApi.ListTransactions(ctx, ledger).
+			PaginationToken(query.PaginationToken).
+			Execute()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret.Cursor, nil
 }
 
 func (d DefaultLedger) AddMetadataToAccount(ctx context.Context, ledger, account string, metadata core.Metadata) error {
@@ -35,7 +70,7 @@ func (d DefaultLedger) GetAccount(ctx context.Context, ledger, account string) (
 	return &ret.Data, err
 }
 
-func (d DefaultLedger) ListAccounts(ctx context.Context, ledger string, query ListAccountQuery) (*sdk.ListAccounts200ResponseCursor, error) {
+func (d DefaultLedger) ListAccounts(ctx context.Context, ledger string, query ListAccountsQuery) (*sdk.ListAccounts200ResponseCursor, error) {
 	var (
 		ret *sdk.ListAccounts200Response
 		err error


### PR DESCRIPTION
# Add transactions list

Add endpoint GET /transactions.
Add a metadata "wallets = true" on transactions generated by the service.

By default, the endpoint returns all transactions generated by the service.
To filter on a specific wallet, use "wallet_id" query parameter.