### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,30 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
-        "revCount": 964859,
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
+        "revCount": 909173,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.964859%2Brev-b40629efe5d6ec48dd1efba650c797ddbd39ace0/019d03e9-2959-7276-adaa-d074e96422de/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.909173%2Brev-44bae273f9f82d480273bab26f5c50de3724f52f/019cdb71-ee45-7469-aca0-9d5b9fedf5c5/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "revCount": 960399,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.960399%2Brev-9dcb002ca1690658be4a04645215baea8b95f31d/019cd400-6f38-7074-b8c8-f84603ddd88b/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
       }
     },
     "nur": {
@@ -59,6 +73,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "Wallets dev env";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2511";
+    nixpkgs-unstable.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
 
     nur = {
       url = "github:nix-community/NUR";
@@ -10,10 +11,8 @@
     };
   };
 
-  outputs = { self, nixpkgs, nur }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nur }:
     let
-      goVersion = 24;
-
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -26,11 +25,16 @@
           let
             pkgs = import nixpkgs {
               inherit system;
-              overlays = [ self.overlays.default nur.overlays.default ];
-              config.allowUnfree = true;
+              overlays = [ nur.overlays.default ];
+              config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+                "goreleaser-pro"
+              ];
+            };
+            pkgs-unstable = import nixpkgs-unstable {
+              inherit system;
             };
           in
-          f { pkgs = pkgs; system = system; }
+          f { pkgs = pkgs; pkgs-unstable = pkgs-unstable; system = system; }
         );
 
       speakeasyVersion = "1.351.0";
@@ -49,11 +53,7 @@
 
     in
     {
-      overlays.default = final: prev: {
-        go = final."go_1_${toString goVersion}";
-      };
-
-      packages = forEachSupportedSystem ({ pkgs, system }:
+      packages = forEachSupportedSystem ({ pkgs, pkgs-unstable, system }:
         {
           speakeasy = pkgs.stdenv.mkDerivation {
             pname = "speakeasy";
@@ -84,18 +84,25 @@
       defaultPackage.x86_64-darwin  = self.packages.x86_64-darwin.speakeasy;
       defaultPackage.aarch64-darwin = self.packages.aarch64-darwin.speakeasy;
 
-      devShells = forEachSupportedSystem ({ pkgs, system }:
+      devShells = forEachSupportedSystem ({ pkgs, pkgs-unstable, system }:
+        let
+          stablePackages = with pkgs; [
+            ginkgo
+            go_1_26
+            gotools
+            just
+          ];
+          unstablePackages = with pkgs-unstable; [
+            golangci-lint
+          ];
+          otherPackages = [
+            pkgs.nur.repos.goreleaser.goreleaser-pro
+            self.packages.${system}.speakeasy
+          ];
+        in
         {
           default = pkgs.mkShell {
-            packages = with pkgs; [
-              go
-              gotools
-              golangci-lint
-              ginkgo
-              pkgs.nur.repos.goreleaser.goreleaser-pro
-              self.packages.${system}.speakeasy
-              just
-            ];
+            packages = stablePackages ++ unstablePackages ++ otherPackages;
           };
         }
       );


### PR DESCRIPTION
## Summary
- Upgrade Go toolchain from 1.23 to 1.26 in nix dev shell
- Modernize flake.nix to use stable/unstable nixpkgs split
- Use `allowUnfreePredicate` instead of `allowUnfree = true`
- Update nix flake lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)