### PR TITLE
fix: upgrade Nix flake Go version to 1.24 and fix lint errors

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,12 +23,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
-        "revCount": 738982,
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "revCount": 964859,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.738982%2Brev-5df43628fdf08d642be8ba5b3625a6c70731c19c/01947627-561b-7a9f-a379-f9ac4c680cb0/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.964859%2Brev-b40629efe5d6ec48dd1efba650c797ddbd39ace0/019d03e9-2959-7276-adaa-d074e96422de/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -40,15 +40,14 @@
         "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1737355203,
-        "narHash": "sha256-nJ2OakILvf7Z+4jl1z/db91YdzHr9QRmGJEXBXJj9WM=",
+        "lastModified": 1773995199,
+        "narHash": "sha256-kk0qP4av44iEXXFSM8jHFav6UmZQTWdTXL8akBY/9yY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "faa786a8b89e71301d620cb1320df7b2195d8b54",
+        "rev": "95f13832a9c21e62b9ded15280102dc73cf6826d",
         "type": "github"
       },
       "original": {
@@ -61,27 +60,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs",
         "nur": "nur"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nur",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733222881,
-        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
 
   outputs = { self, nixpkgs, nur }:
     let
-      goVersion = 23;
+      goVersion = 24;
 
       supportedSystems = [
         "x86_64-linux"

--- a/pkg/testserver/testserver.go
+++ b/pkg/testserver/testserver.go
@@ -5,10 +5,10 @@ import (
 	"github.com/formancehq/go-libs/v3/httpserver"
 	"github.com/formancehq/go-libs/v3/testing/deferred"
 	"github.com/formancehq/go-libs/v3/testing/testservice"
-	. "github.com/formancehq/go-libs/v3/testing/testservice/ginkgo"
+	testserviceginkgo "github.com/formancehq/go-libs/v3/testing/testservice/ginkgo"
 	"github.com/formancehq/wallets/cmd"
 	walletsclient "github.com/formancehq/wallets/pkg/client"
-	. "github.com/onsi/ginkgo/v2/dsl/core"
+	ginkgocore "github.com/onsi/ginkgo/v2/dsl/core"
 )
 
 func StackURLInstrumentation(stackURL *deferred.Deferred[string]) testservice.Instrumentation {
@@ -26,9 +26,9 @@ func StackURLInstrumentation(stackURL *deferred.Deferred[string]) testservice.In
 }
 
 func DeferTestServer(stackURL *deferred.Deferred[string], options ...testservice.Option) *deferred.Deferred[*testservice.Service] {
-	return DeferNew(cmd.NewRootCommand,
+	return testserviceginkgo.DeferNew(cmd.NewRootCommand,
 		append([]testservice.Option{
-			testservice.WithLogger(GinkgoT()),
+			testservice.WithLogger(ginkgocore.GinkgoT()),
 			testservice.WithInstruments(
 				testservice.AppendArgsInstrumentation("serve", "--"+cmd.ListenFlag, ":0"),
 				testservice.InstrumentationFunc(func(ctx context.Context, cfg *testservice.RunConfiguration) error {


### PR DESCRIPTION
## Summary
- **Bump Go version in Nix flake** from 1.23 to 1.24 to match `go.mod` (Go 1.24.0 / toolchain go1.24.10). This was causing `golangci-lint` to fail with: `the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.10)`
- **Update `flake.lock`** with latest nixpkgs and NUR inputs
- **Fix staticcheck ST1001** lint errors in `pkg/testserver/testserver.go` by replacing dot imports with named imports

## Test plan
- [x] `just pre-commit` passes locally (generate, tidy, lint — 0 issues)
- [ ] CI pipeline passes on this PR