### PR TITLE
feat: add HTTP audit middleware

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -7,7 +7,9 @@ import (
 	sharedapi "github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
 	"github.com/formancehq/go-libs/v5/pkg/fx/authnfx"
+	"github.com/formancehq/go-libs/v5/pkg/fx/messagingfx"
 	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
 	"github.com/formancehq/go-libs/v5/pkg/observe"
 	"github.com/formancehq/go-libs/v5/pkg/observe/traces"
 	"github.com/formancehq/go-libs/v5/pkg/authn/licence"
@@ -61,6 +63,7 @@ func newServeCommand() *cobra.Command {
 					Version: Version,
 					Debug:   service.IsDebug(cmd),
 				}, listen),
+				messagingfx.PublishModuleFromFlags(cmd, service.IsDebug(cmd)),
 				observefx.ResourceModuleFromFlags(cmd),
 				observefx.TracesModuleFromFlags(cmd),
 				authnfx.JWTModuleFromFlags(cmd),
@@ -81,6 +84,7 @@ func newServeCommand() *cobra.Command {
 	licence.AddFlags(cmd.Flags())
 	jwt.AddFlags(cmd.Flags())
 	traces.AddFlags(cmd.Flags())
+	publish.AddFlags(ServiceName, cmd.Flags())
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/formancehq/wallets/pkg/client => ./pkg/client
 require (
 	github.com/ThreeDotsLabs/watermill v1.5.1
 	github.com/formancehq/formance-sdk-go/v3 v3.8.1
-	github.com/formancehq/go-libs/v5 v5.1.1-0.20260522070511-b6560f0a520c
+	github.com/formancehq/go-libs/v5 v5.1.1-0.20260522083443-d2a60ed2e0dd
 	github.com/formancehq/ledger v0.0.0-20260420112415-04500870a72d
 	github.com/formancehq/wallets/pkg/client v0.0.0-00010101000000-000000000000
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.26.0
 replace github.com/formancehq/wallets/pkg/client => ./pkg/client
 
 require (
+	github.com/ThreeDotsLabs/watermill v1.5.1
 	github.com/formancehq/formance-sdk-go/v3 v3.8.1
-	github.com/formancehq/go-libs/v5 v5.0.1
+	github.com/formancehq/go-libs/v5 v5.1.1-0.20260522070511-b6560f0a520c
 	github.com/formancehq/ledger v0.0.0-20260420112415-04500870a72d
 	github.com/formancehq/wallets/pkg/client v0.0.0-00010101000000-000000000000
 	github.com/go-chi/chi/v5 v5.2.5
@@ -31,7 +32,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
-	github.com/ThreeDotsLabs/watermill v1.5.1 // indirect
 	github.com/ThreeDotsLabs/watermill-aws v1.0.1 // indirect
 	github.com/ThreeDotsLabs/watermill-http/v2 v2.3.1 // indirect
 	github.com/ThreeDotsLabs/watermill-kafka/v3 v3.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/formancehq/formance-sdk-go/v3 v3.8.1 h1:nKWcpZT70vegEUV+/Xl/wekiI1PsCFVe7mvGgwaA9fk=
 github.com/formancehq/formance-sdk-go/v3 v3.8.1/go.mod h1:2Kb2Z4bN8/I4MQQnuSilvThqeaUtuLaTdmMGIb3nMJY=
-github.com/formancehq/go-libs/v5 v5.0.1 h1:So9QPvNEhjQN7+qqoZdac4RmTB9zo5c9IBPCjr8Q4AQ=
-github.com/formancehq/go-libs/v5 v5.0.1/go.mod h1:DPhflA156M13nyGCsGS2XAVtyZwYBkUo+jjCSvs9UF8=
+github.com/formancehq/go-libs/v5 v5.1.1-0.20260522070511-b6560f0a520c h1:Ru8+qSTDXaamCVemCzZmVCHgcJFZ0tBc4V0WCRr7WVc=
+github.com/formancehq/go-libs/v5 v5.1.1-0.20260522070511-b6560f0a520c/go.mod h1:0zJ6yzF4/Pu9lmKpswaEdQChpnxuMFsTxmhTCE1raXk=
 github.com/formancehq/ledger v0.0.0-20260420112415-04500870a72d h1:K9/kJT5MgJMtr53IXphaJZvYqsPsveWTTaQwflHsfbk=
 github.com/formancehq/ledger v0.0.0-20260420112415-04500870a72d/go.mod h1:97C6bg7eJ/sIRMnrc6YY4V9AYlKd7alcBSsvqTboweo=
 github.com/formancehq/ledger/pkg/client v0.0.0-20260416070424-5a335109905b h1:ZdqiY3SB3bQWgN5VJyW2WRicSQhTqayVtIoKt+x1dug=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/formancehq/formance-sdk-go/v3 v3.8.1 h1:nKWcpZT70vegEUV+/Xl/wekiI1PsCFVe7mvGgwaA9fk=
 github.com/formancehq/formance-sdk-go/v3 v3.8.1/go.mod h1:2Kb2Z4bN8/I4MQQnuSilvThqeaUtuLaTdmMGIb3nMJY=
-github.com/formancehq/go-libs/v5 v5.1.1-0.20260522070511-b6560f0a520c h1:Ru8+qSTDXaamCVemCzZmVCHgcJFZ0tBc4V0WCRr7WVc=
-github.com/formancehq/go-libs/v5 v5.1.1-0.20260522070511-b6560f0a520c/go.mod h1:0zJ6yzF4/Pu9lmKpswaEdQChpnxuMFsTxmhTCE1raXk=
+github.com/formancehq/go-libs/v5 v5.1.1-0.20260522083443-d2a60ed2e0dd h1:bXQ9pFcrDoaBFMzAyRNac5EWRuBn//wtQPzl5sXJcvU=
+github.com/formancehq/go-libs/v5 v5.1.1-0.20260522083443-d2a60ed2e0dd/go.mod h1:0zJ6yzF4/Pu9lmKpswaEdQChpnxuMFsTxmhTCE1raXk=
 github.com/formancehq/ledger v0.0.0-20260420112415-04500870a72d h1:K9/kJT5MgJMtr53IXphaJZvYqsPsveWTTaQwflHsfbk=
 github.com/formancehq/ledger v0.0.0-20260420112415-04500870a72d/go.mod h1:97C6bg7eJ/sIRMnrc6YY4V9AYlKd7alcBSsvqTboweo=
 github.com/formancehq/ledger/pkg/client v0.0.0-20260416070424-5a335109905b h1:ZdqiY3SB3bQWgN5VJyW2WRicSQhTqayVtIoKt+x1dug=

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver"
-	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver/audit"
+	"github.com/formancehq/go-libs/v5/pkg/audit/httpaudit"
 
 	sharedapi "github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
@@ -31,7 +31,7 @@ func NewRouter(
 			handler.ServeHTTP(w, r)
 		})
 	})
-	r.Use(audit.Middleware(publisher, "audit-events", "wallets"))
+	r.Use(httpaudit.Middleware(publisher, "audit-events", "wallets", nil))
 
 	r.Get("/_healthcheck", healthController.Check)
 	r.Get("/_info", sharedapi.InfoHandler(serviceInfo))

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -3,9 +3,11 @@ package api
 import (
 	"net/http"
 
+	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/go-chi/chi/v5"
 
 	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver"
+	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver/audit"
 
 	sharedapi "github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
@@ -19,6 +21,7 @@ func NewRouter(
 	healthController *sharedhealth.HealthController,
 	serviceInfo sharedapi.ServiceInfo,
 	authenticator jwt.Authenticator,
+	publisher message.Publisher,
 ) *chi.Mux {
 	r := chi.NewRouter()
 
@@ -28,6 +31,7 @@ func NewRouter(
 			handler.ServeHTTP(w, r)
 		})
 	})
+	r.Use(audit.Middleware(publisher, "audit-events", "wallets"))
 
 	r.Get("/_healthcheck", healthController.Check)
 	r.Get("/_info", sharedapi.InfoHandler(serviceInfo))

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -18,6 +18,7 @@ import (
 
 	sharedapi "github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/go-libs/v5/pkg/authn/jwt"
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
 	sharedhealth "github.com/formancehq/go-libs/v5/pkg/service/health"
 	wallet "github.com/formancehq/wallets/pkg"
 	"github.com/stretchr/testify/require"
@@ -89,7 +90,7 @@ func newTestEnv(opts ...Option) *testEnv {
 	ret.router = NewRouter(manager, &sharedhealth.HealthController{}, sharedapi.ServiceInfo{
 		Version: "latest",
 		Debug:   testing.Verbose(),
-	}, jwt.NewNoAuth())
+	}, jwt.NewNoAuth(), publish.InMemory())
 	return ret
 }
 


### PR DESCRIPTION
## Summary
- Wire the go-libs audit middleware into the wallets HTTP router
- Add messaging infrastructure (publish flags + messagingfx module) for audit event publishing
- Captures request/response data and publishes audit events via Watermill

Depends on: https://github.com/formancehq/go-libs/pull/604

## Test plan
- [x] Module compiles successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)