### PR TITLE
fix(security): validate account names to prevent Numscript injection (EN-1200)

### DIFF
--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -40,6 +40,24 @@ var balanceCreateTestCases = []balanceCreateTestCase{
 		expectedErrorCode:  ErrorCodeValidation,
 	},
 	{
+		// The name contains valid characters but also an account separator;
+		// an unanchored regex would have accepted it, allowing address/script injection.
+		name: "with name containing an account separator",
+		request: wallet.CreateBalance{
+			Name: "balance:injected",
+		},
+		expectedStatusCode: http.StatusBadRequest,
+		expectedErrorCode:  ErrorCodeValidation,
+	},
+	{
+		name: "with name containing whitespace and numscript tokens",
+		request: wallet.CreateBalance{
+			Name: "x\n@world",
+		},
+		expectedStatusCode: http.StatusBadRequest,
+		expectedErrorCode:  ErrorCodeValidation,
+	},
+	{
 		name: "with reserved name",
 		request: wallet.CreateBalance{
 			Name: wallet.MainBalance,

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -28,7 +28,7 @@ var balanceCreateTestCases = []balanceCreateTestCase{
 	{
 		name: "nominal",
 		request: wallet.CreateBalance{
-			Name: uuid.NewString(),
+			Name: "balance1",
 		},
 	},
 	{
@@ -53,6 +53,14 @@ var balanceCreateTestCases = []balanceCreateTestCase{
 		name: "with name containing whitespace and numscript tokens",
 		request: wallet.CreateBalance{
 			Name: "x\n@world",
+		},
+		expectedStatusCode: http.StatusBadRequest,
+		expectedErrorCode:  ErrorCodeValidation,
+	},
+	{
+		name: "with name containing a dash",
+		request: wallet.CreateBalance{
+			Name: "foo-bar",
 		},
 		expectedStatusCode: http.StatusBadRequest,
 		expectedErrorCode:  ErrorCodeValidation,

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -58,12 +58,12 @@ var balanceCreateTestCases = []balanceCreateTestCase{
 		expectedErrorCode:  ErrorCodeValidation,
 	},
 	{
+		// Dashes are allowed: dashed/UUID balance names must keep working.
+		// (They still alias under Address.String(); see chart.go.)
 		name: "with name containing a dash",
 		request: wallet.CreateBalance{
 			Name: "foo-bar",
 		},
-		expectedStatusCode: http.StatusBadRequest,
-		expectedErrorCode:  ErrorCodeValidation,
 	},
 	{
 		name: "with reserved name",

--- a/pkg/api/handler_wallets_credit_test.go
+++ b/pkg/api/handler_wallets_credit_test.go
@@ -126,15 +126,29 @@ func TestWalletsCredit(t *testing.T) {
 			expectedErrorCode:  ErrorCodeValidation,
 		},
 		{
-			name: "with wallet source containing dash in balance",
+			// Dashes are allowed in balance names (they still alias under
+			// Address.String(); see chart.go), so a dashed wallet source resolves.
+			name: "with dashed balance in wallet source",
 			request: wallet.CreditRequest{
 				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
 				Sources: []wallet.Subject{
 					wallet.NewWalletSubject("emitter1", "foo-bar"),
 				},
 			},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedErrorCode:  ErrorCodeValidation,
+			expectedPostTransaction: func(testEnv *testEnv, walletID string) wallet.PostTransaction {
+				return wallet.PostTransaction{
+					Script: &shared.V2PostTransactionScript{
+						Plain: pointer.For(wallet.BuildCreditWalletScript(
+							testEnv.Chart().GetBalanceAccount("emitter1", "foo-bar"),
+						)),
+						Vars: map[string]string{
+							"destination": testEnv.Chart().GetMainBalanceAccount(walletID),
+							"amount":      "USD 100",
+						},
+					},
+					Metadata: wallet.TransactionMetadata(nil),
+				}
+			},
 		},
 		{
 			name: "with wallet source containing numscript injection in identifier",
@@ -148,13 +162,25 @@ func TestWalletsCredit(t *testing.T) {
 			expectedErrorCode:  ErrorCodeValidation,
 		},
 		{
-			name: "with dash in destination balance",
+			// Dashes are allowed in balance names (still alias under
+			// Address.String(); see chart.go), so a dashed destination resolves.
+			name: "with dashed destination balance",
 			request: wallet.CreditRequest{
 				Amount:  wallet.NewMonetary(big.NewInt(100), "USD"),
 				Balance: "foo-bar",
 			},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedErrorCode:  ErrorCodeValidation,
+			expectedPostTransaction: func(testEnv *testEnv, walletID string) wallet.PostTransaction {
+				return wallet.PostTransaction{
+					Script: &shared.V2PostTransactionScript{
+						Plain: pointer.For(wallet.BuildCreditWalletScript("world")),
+						Vars: map[string]string{
+							"destination": testEnv.Chart().GetBalanceAccount(walletID, "foo-bar"),
+							"amount":      "USD 100",
+						},
+					},
+					Metadata: wallet.TransactionMetadata(nil),
+				}
+			},
 		},
 		{
 			name: "with secondary balance as destination",
@@ -212,6 +238,7 @@ func TestWalletsCredit(t *testing.T) {
 			t.Parallel()
 			walletID := uuid.NewString()
 			secondaryBalance := wallet.NewBalance("secondary", nil)
+			dashedBalance := wallet.NewBalance("foo-bar", nil)
 
 			req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/credit", testCase.request)
 			rec := httptest.NewRecorder()
@@ -227,13 +254,15 @@ func TestWalletsCredit(t *testing.T) {
 					return &testCase.postTransactionResult, nil
 				}),
 				WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
-					if testEnv.Chart().GetBalanceAccount(walletID, secondaryBalance.Name) == account {
-						return &wallet.AccountWithVolumesAndBalances{
-							Account: wallet.Account{
-								Address:  account,
-								Metadata: metadataWithExpectingTypesAfterUnmarshalling(secondaryBalance.LedgerMetadata(walletID)),
-							},
-						}, nil
+					for _, b := range []wallet.Balance{secondaryBalance, dashedBalance} {
+						if testEnv.Chart().GetBalanceAccount(walletID, b.Name) == account {
+							return &wallet.AccountWithVolumesAndBalances{
+								Account: wallet.Account{
+									Address:  account,
+									Metadata: metadataWithExpectingTypesAfterUnmarshalling(b.LedgerMetadata(walletID)),
+								},
+							}, nil
+						}
 					}
 					return &wallet.AccountWithVolumesAndBalances{
 						Account: wallet.Account{

--- a/pkg/api/handler_wallets_credit_test.go
+++ b/pkg/api/handler_wallets_credit_test.go
@@ -114,6 +114,17 @@ func TestWalletsCredit(t *testing.T) {
 			expectedErrorCode:  ErrorCodeValidation,
 		},
 		{
+			name: "with wallet source spanning multiple account segments",
+			request: wallet.CreditRequest{
+				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
+				Sources: []wallet.Subject{
+					wallet.NewWalletSubject("emitter1", "balance:injected"),
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorCode:  ErrorCodeValidation,
+		},
+		{
 			name: "with wallet source containing numscript injection in identifier",
 			request: wallet.CreditRequest{
 				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),

--- a/pkg/api/handler_wallets_credit_test.go
+++ b/pkg/api/handler_wallets_credit_test.go
@@ -125,12 +125,32 @@ func TestWalletsCredit(t *testing.T) {
 			expectedErrorCode:  ErrorCodeValidation,
 		},
 		{
+			name: "with wallet source containing dash in balance",
+			request: wallet.CreditRequest{
+				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
+				Sources: []wallet.Subject{
+					wallet.NewWalletSubject("emitter1", "foo-bar"),
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorCode:  ErrorCodeValidation,
+		},
+		{
 			name: "with wallet source containing numscript injection in identifier",
 			request: wallet.CreditRequest{
 				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
 				Sources: []wallet.Subject{
 					wallet.NewWalletSubject("emitter1 @world", ""),
 				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorCode:  ErrorCodeValidation,
+		},
+		{
+			name: "with dash in destination balance",
+			request: wallet.CreditRequest{
+				Amount:  wallet.NewMonetary(big.NewInt(100), "USD"),
+				Balance: "foo-bar",
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  ErrorCodeValidation,
@@ -158,7 +178,7 @@ func TestWalletsCredit(t *testing.T) {
 			name: "with not existing secondary balance as destination",
 			request: wallet.CreditRequest{
 				Amount:  wallet.NewMonetary(big.NewInt(100), "USD"),
-				Balance: "not-existing",
+				Balance: "not_existing",
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  ErrorCodeValidation,

--- a/pkg/api/handler_wallets_credit_test.go
+++ b/pkg/api/handler_wallets_credit_test.go
@@ -103,6 +103,28 @@ func TestWalletsCredit(t *testing.T) {
 			},
 		},
 		{
+			name: "with wallet source containing numscript injection in balance",
+			request: wallet.CreditRequest{
+				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
+				Sources: []wallet.Subject{
+					wallet.NewWalletSubject("emitter1", "secondary\n@world"),
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorCode:  ErrorCodeValidation,
+		},
+		{
+			name: "with wallet source containing numscript injection in identifier",
+			request: wallet.CreditRequest{
+				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
+				Sources: []wallet.Subject{
+					wallet.NewWalletSubject("emitter1 @world", ""),
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorCode:  ErrorCodeValidation,
+		},
+		{
 			name: "with secondary balance as destination",
 			request: wallet.CreditRequest{
 				Amount:  wallet.NewMonetary(big.NewInt(100), "USD"),

--- a/pkg/api/handler_wallets_credit_test.go
+++ b/pkg/api/handler_wallets_credit_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
@@ -258,6 +259,45 @@ func TestWalletsCredit(t *testing.T) {
 				errorResponse := readErrorResponse(t, rec)
 				require.Equal(t, ErrorCodeValidation, errorResponse.ErrorCode)
 			}
+		})
+	}
+}
+
+// TestWalletsCreditRejectsInvalidWalletID guards the WalletID supplied via the
+// URL path: a value spanning multiple account segments or carrying Numscript
+// tokens must be rejected before any ledger transaction is created.
+func TestWalletsCreditRejectsInvalidWalletID(t *testing.T) {
+	t.Parallel()
+
+	for _, walletID := range []string{
+		"wallet:injected",
+		"wallet\n@world",
+	} {
+		walletID := walletID
+		t.Run(walletID, func(t *testing.T) {
+			t.Parallel()
+
+			req := newRequest(t, http.MethodPost, "/wallets/"+url.PathEscape(walletID)+"/credit", wallet.CreditRequest{
+				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
+			})
+			rec := httptest.NewRecorder()
+
+			var (
+				testEnv            *testEnv
+				createdTransaction bool
+			)
+			testEnv = newTestEnv(
+				WithCreateTransaction(func(ctx context.Context, ledger, ik string, p wallet.PostTransaction) (*shared.V2Transaction, error) {
+					createdTransaction = true
+					return &shared.V2Transaction{}, nil
+				}),
+			)
+			testEnv.Router().ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+			errorResponse := readErrorResponse(t, rec)
+			require.Equal(t, ErrorCodeValidation, errorResponse.ErrorCode)
+			require.False(t, createdTransaction)
 		})
 	}
 }

--- a/pkg/api/handler_wallets_debit_test.go
+++ b/pkg/api/handler_wallets_debit_test.go
@@ -183,6 +183,15 @@ var walletDebitTestCases = []testCase{
 		},
 	},
 	{
+		name: "with dash in balance source",
+		request: wallet.DebitRequest{
+			Amount:   wallet.NewMonetary(big.NewInt(100), "USD"),
+			Balances: []string{"foo-bar"},
+		},
+		expectedStatusCode: http.StatusBadRequest,
+		expectedErrorCode:  string(sdkerrors.SchemasErrorCodeValidation),
+	},
+	{
 		name: "with wildcard balance as source",
 		request: wallet.DebitRequest{
 			Amount:   wallet.NewMonetary(big.NewInt(100), "USD"),
@@ -415,4 +424,44 @@ func TestWalletsDebit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWalletsDebitRejectsInvalidBalanceMetadata(t *testing.T) {
+	t.Parallel()
+
+	walletID := uuid.NewString()
+	req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/debit", wallet.DebitRequest{
+		Amount:   wallet.NewMonetary(big.NewInt(100), "USD"),
+		Balances: []string{"legacy"},
+	})
+	rec := httptest.NewRecorder()
+
+	var (
+		createdTransaction bool
+		testEnv            *testEnv
+	)
+	testEnv = newTestEnv(
+		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
+			require.Equal(t, testEnv.Chart().GetBalanceAccount(walletID, "legacy"), account)
+			return &wallet.AccountWithVolumesAndBalances{
+				Account: wallet.Account{
+					Address: account,
+					Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
+						Name: "foo-bar",
+					}.LedgerMetadata(walletID)),
+				},
+			}, nil
+		}),
+		WithCreateTransaction(func(ctx context.Context, ledger, ik string, p wallet.PostTransaction) (*shared.V2Transaction, error) {
+			createdTransaction = true
+			return nil, nil
+		}),
+	)
+
+	testEnv.Router().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+	errorResponse := readErrorResponse(t, rec)
+	require.Equal(t, ErrorCodeValidation, errorResponse.ErrorCode)
+	require.False(t, createdTransaction)
 }

--- a/pkg/api/handler_wallets_debit_test.go
+++ b/pkg/api/handler_wallets_debit_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
@@ -454,7 +455,7 @@ func TestWalletsDebitRejectsInvalidBalanceMetadata(t *testing.T) {
 		}),
 		WithCreateTransaction(func(ctx context.Context, ledger, ik string, p wallet.PostTransaction) (*shared.V2Transaction, error) {
 			createdTransaction = true
-			return nil, nil
+			return &shared.V2Transaction{}, nil
 		}),
 	)
 
@@ -464,4 +465,43 @@ func TestWalletsDebitRejectsInvalidBalanceMetadata(t *testing.T) {
 	errorResponse := readErrorResponse(t, rec)
 	require.Equal(t, ErrorCodeValidation, errorResponse.ErrorCode)
 	require.False(t, createdTransaction)
+}
+
+// TestWalletsDebitRejectsInvalidWalletID guards the WalletID supplied via the
+// URL path: a value spanning multiple account segments or carrying Numscript
+// tokens must be rejected before any ledger transaction is created.
+func TestWalletsDebitRejectsInvalidWalletID(t *testing.T) {
+	t.Parallel()
+
+	for _, walletID := range []string{
+		"wallet:injected",
+		"wallet\n@world",
+	} {
+		walletID := walletID
+		t.Run(walletID, func(t *testing.T) {
+			t.Parallel()
+
+			req := newRequest(t, http.MethodPost, "/wallets/"+url.PathEscape(walletID)+"/debit", wallet.DebitRequest{
+				Amount: wallet.NewMonetary(big.NewInt(100), "USD"),
+			})
+			rec := httptest.NewRecorder()
+
+			var (
+				testEnv            *testEnv
+				createdTransaction bool
+			)
+			testEnv = newTestEnv(
+				WithCreateTransaction(func(ctx context.Context, ledger, ik string, p wallet.PostTransaction) (*shared.V2Transaction, error) {
+					createdTransaction = true
+					return &shared.V2Transaction{}, nil
+				}),
+			)
+			testEnv.Router().ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+			errorResponse := readErrorResponse(t, rec)
+			require.Equal(t, ErrorCodeValidation, errorResponse.ErrorCode)
+			require.False(t, createdTransaction)
+		})
+	}
 }

--- a/pkg/api/handler_wallets_debit_test.go
+++ b/pkg/api/handler_wallets_debit_test.go
@@ -184,13 +184,25 @@ var walletDebitTestCases = []testCase{
 		},
 	},
 	{
-		name: "with dash in balance source",
+		// Dashes are allowed in balance names (still alias under
+		// Address.String(); see chart.go), so a dashed balance source resolves.
+		name: "with dashed balance source",
 		request: wallet.DebitRequest{
 			Amount:   wallet.NewMonetary(big.NewInt(100), "USD"),
 			Balances: []string{"foo-bar"},
 		},
-		expectedStatusCode: http.StatusBadRequest,
-		expectedErrorCode:  string(sdkerrors.SchemasErrorCodeValidation),
+		expectedPostTransaction: func(testEnv *testEnv, walletID string, h *wallet.DebitHold) wallet.PostTransaction {
+			return wallet.PostTransaction{
+				Script: &shared.V2PostTransactionScript{
+					Plain: pointer.For(wallet.BuildDebitWalletScript(map[string]map[string]string{}, testEnv.Chart().GetBalanceAccount(walletID, "foo-bar"))),
+					Vars: map[string]string{
+						"destination": "world",
+						"amount":      "USD 100",
+					},
+				},
+				Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.TransactionMetadata(nil)),
+			}
+		},
 	},
 	{
 		name: "with wildcard balance as source",
@@ -328,6 +340,15 @@ func TestWalletsDebit(t *testing.T) {
 								}.LedgerMetadata(walletID)),
 							},
 						}, nil
+					case testEnv.Chart().GetBalanceAccount(walletID, "foo-bar"):
+						return &wallet.AccountWithVolumesAndBalances{
+							Account: wallet.Account{
+								Address: testEnv.Chart().GetBalanceAccount(walletID, "foo-bar"),
+								Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
+									Name: "foo-bar",
+								}.LedgerMetadata(walletID)),
+							},
+						}, nil
 					default:
 						return nil, errors.New("unexpected account: " + account)
 					}
@@ -447,8 +468,12 @@ func TestWalletsDebitRejectsInvalidBalanceMetadata(t *testing.T) {
 			return &wallet.AccountWithVolumesAndBalances{
 				Account: wallet.Account{
 					Address: account,
+					// A stored balance name carrying Numscript tokens (e.g. tampered
+					// ledger metadata) must be rejected on read-back before any
+					// transaction is built. Dashes alone are valid, so use a real
+					// injection vector here.
 					Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
-						Name: "foo-bar",
+						Name: "injected\n@world",
 					}.LedgerMetadata(walletID)),
 				},
 			}, nil

--- a/pkg/balance.go
+++ b/pkg/balance.go
@@ -12,18 +12,11 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
 )
 
-// balanceNameRegex constrains a user-supplied balance name to a single,
-// anchored ledger segment (no ':' separator), which closes the Numscript
-// injection vector while still allowing names clients rely on, including
-// dashed names and UUIDs.
-//
-// NOTE: Address.String() currently strips '-', so "foo-bar" and "foobar"
-// resolve to the same ledger account. Forbidding '-' here would break
-// legitimate dashed/UUID names, and removing the global strip would change
-// the address of every already-created wallet/balance; resolving that
-// collision cleanly needs a coordinated change to Address.String() plus a
-// data migration, tracked separately.
-var balanceNameRegex = regexp.MustCompile("^[0-9A-Za-z_-]+$")
+// balanceNameRegex constrains user-supplied balance names to a single,
+// anchored ledger segment (no ':' separator) and excludes '-' because
+// Address.String() strips dashes globally, making "foo-bar" and "foobar"
+// resolve to the same ledger account.
+var balanceNameRegex = regexp.MustCompile("^[0-9A-Za-z_]+$")
 
 type CreateBalance struct {
 	WalletID  string     `json:"walletID"`

--- a/pkg/balance.go
+++ b/pkg/balance.go
@@ -13,10 +13,15 @@ import (
 )
 
 // balanceNameRegex constrains user-supplied balance names to a single,
-// anchored ledger segment (no ':' separator) and excludes '-' because
-// Address.String() strips dashes globally, making "foo-bar" and "foobar"
-// resolve to the same ledger account.
-var balanceNameRegex = regexp.MustCompile("^[0-9A-Za-z_]+$")
+// anchored ledger segment: it permits [0-9A-Za-z_-] but no ':' separator,
+// whitespace or Numscript metacharacters (the actual injection vectors).
+//
+// Dashes are allowed so legitimate dashed/UUID balance names keep working.
+// This does NOT make names collision-free: per the warning on
+// Address.String(), "foo-bar" still resolves to the same ledger account as
+// "foobar". Allowing dashes only prevents validation from rejecting existing
+// data — the aliasing itself is tracked as a separate ticket.
+var balanceNameRegex = regexp.MustCompile("^[0-9A-Za-z_-]+$")
 
 type CreateBalance struct {
 	WalletID  string     `json:"walletID"`

--- a/pkg/balance.go
+++ b/pkg/balance.go
@@ -12,7 +12,7 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
 )
 
-var balanceNameRegex = regexp.MustCompile("[0-9A-Za-z_-]+")
+var balanceNameRegex = regexp.MustCompile("^[0-9A-Za-z_-]+$")
 
 type CreateBalance struct {
 	WalletID  string     `json:"walletID"`

--- a/pkg/balance.go
+++ b/pkg/balance.go
@@ -12,6 +12,17 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
 )
 
+// balanceNameRegex constrains a user-supplied balance name to a single,
+// anchored ledger segment (no ':' separator), which closes the Numscript
+// injection vector while still allowing names clients rely on, including
+// dashed names and UUIDs.
+//
+// NOTE: Address.String() currently strips '-', so "foo-bar" and "foobar"
+// resolve to the same ledger account. Forbidding '-' here would break
+// legitimate dashed/UUID names, and removing the global strip would change
+// the address of every already-created wallet/balance; resolving that
+// collision cleanly needs a coordinated change to Address.String() plus a
+// data migration, tracked separately.
 var balanceNameRegex = regexp.MustCompile("^[0-9A-Za-z_-]+$")
 
 type CreateBalance struct {

--- a/pkg/chart.go
+++ b/pkg/chart.go
@@ -20,12 +20,20 @@ type Address []string
 // account, causing silent collisions on create/get/debit/credit — two
 // wallets, balances, or holds sharing one ledger account.
 //
+// Scope: this only affects segments routed through the Chart — wallet IDs,
+// balance names and hold IDs. SubjectTypeLedgerAccount identifiers are used
+// verbatim (see Subject.getAccount) and bypass this strip, so their dashes
+// are preserved.
+//
+// Note segment validation deliberately ALLOWS '-' (so dashed/UUID names keep
+// working), which means this collision is live, not theoretical: a name like
+// "foo-bar" passes validation yet still aliases to "foobar" here.
+//
 // The strip cannot simply be removed: all existing accounts were created
 // with dashes already stripped, so dropping it would change the address of
 // every wallet/balance/hold already in the ledger and requires a data
 // migration. Fixing this properly (stop stripping + migrate) should be a
-// dedicated ticket. Until then, callers validate user-supplied segments to
-// limit — but do not fully eliminate — the collision surface.
+// dedicated ticket.
 func (addr Address) String() string {
 	s := strings.Join(addr, ":")
 	s = strings.ReplaceAll(s, "-", "")

--- a/pkg/chart.go
+++ b/pkg/chart.go
@@ -8,6 +8,24 @@ const MainBalance = "main"
 
 type Address []string
 
+// String renders the address as a ledger account path by joining the
+// segments with ':'.
+//
+// WARNING — known aliasing hazard: every '-' is stripped from the joined
+// result. This means any two segments that differ only by dashes collapse
+// to the same ledger account: "foo-bar" and "foobar" both render to
+// "foobar", as do wallet IDs / balance names / hold IDs differing only in
+// dash placement. Because wallet and hold IDs are UUIDs (which contain
+// dashes), distinct inputs can therefore resolve to the SAME underlying
+// account, causing silent collisions on create/get/debit/credit — two
+// wallets, balances, or holds sharing one ledger account.
+//
+// The strip cannot simply be removed: all existing accounts were created
+// with dashes already stripped, so dropping it would change the address of
+// every wallet/balance/hold already in the ledger and requires a data
+// migration. Fixing this properly (stop stripping + migrate) should be a
+// dedicated ticket. Until then, callers validate user-supplied segments to
+// limit — but do not fully eliminate — the collision surface.
 func (addr Address) String() string {
 	s := strings.Join(addr, ":")
 	s = strings.ReplaceAll(s, "-", "")

--- a/pkg/credit.go
+++ b/pkg/credit.go
@@ -36,6 +36,9 @@ func (c CreditRequest) Validate() error {
 	if !assets.IsValid(c.Amount.Asset) {
 		return newErrInvalidAsset(c.Amount.Asset)
 	}
+	if c.Balance != "" && !balanceNameRegex.MatchString(c.Balance) {
+		return newErrInvalidAccountName(c.Balance)
+	}
 
 	return nil
 }

--- a/pkg/credit.go
+++ b/pkg/credit.go
@@ -48,6 +48,20 @@ type Credit struct {
 	WalletID string `json:"walletID"`
 }
 
+// Validate centralizes all credit validation, including the WalletID, so it
+// cannot be bypassed by callers that only invoke Validate() (mirrors
+// Debit.Validate). The WalletID is used as a chart segment, so it must be a
+// single anchored segment with no ':' separator or Numscript metacharacters.
+func (c Credit) Validate() error {
+	if err := c.CreditRequest.Validate(); err != nil {
+		return err
+	}
+	if !accountSegmentRegexp.MatchString(c.WalletID) {
+		return newErrInvalidAccountName(c.WalletID)
+	}
+	return nil
+}
+
 func (c Credit) destinationAccount(chart *Chart) string {
 	if c.Balance == "" {
 		return chart.GetMainBalanceAccount(c.WalletID)

--- a/pkg/debit.go
+++ b/pkg/debit.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
+	"github.com/formancehq/ledger/pkg/accounts"
 	"github.com/formancehq/ledger/pkg/assets"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
@@ -55,6 +56,9 @@ func (d Debit) getDestination() Subject {
 }
 
 func (d Debit) Validate() error {
+	if !accounts.ValidateAddress(d.WalletID) {
+		return newErrInvalidAccountName(d.WalletID)
+	}
 	if d.Destination != nil {
 		if err := d.Destination.Validate(); err != nil {
 			return err

--- a/pkg/debit.go
+++ b/pkg/debit.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
-	"github.com/formancehq/ledger/pkg/accounts"
 	"github.com/formancehq/ledger/pkg/assets"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
@@ -56,7 +55,7 @@ func (d Debit) getDestination() Subject {
 }
 
 func (d Debit) Validate() error {
-	if !accounts.ValidateAddress(d.WalletID) {
+	if !accountSegmentRegexp.MatchString(d.WalletID) {
 		return newErrInvalidAccountName(d.WalletID)
 	}
 	if d.Destination != nil {

--- a/pkg/debit.go
+++ b/pkg/debit.go
@@ -69,5 +69,10 @@ func (d Debit) Validate() error {
 	if !assets.IsValid(d.Amount.Asset) {
 		return newErrInvalidAsset(d.Amount.Asset)
 	}
+	for _, balance := range d.Balances {
+		if balance != "*" && !balanceNameRegex.MatchString(balance) {
+			return newErrInvalidAccountName(balance)
+		}
+	}
 	return nil
 }

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -169,6 +169,9 @@ func (m *Manager) Debit(ctx context.Context, ik string, debit Debit) (*DebitHold
 		if balance.ExpiresAt != nil && !balance.ExpiresAt.IsZero() && balance.ExpiresAt.Before(time.Now()) {
 			continue
 		}
+		if !balanceNameRegex.MatchString(balance.Name) {
+			return nil, newErrInvalidAccountName(balance.Name)
+		}
 		sources = append(sources, m.chart.GetBalanceAccount(debit.WalletID, balance.Name))
 	}
 

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -287,10 +287,6 @@ func (m *Manager) Credit(ctx context.Context, ik string, credit Credit) error {
 		return err
 	}
 
-	if !accountSegmentRegexp.MatchString(credit.WalletID) {
-		return newErrInvalidAccountName(credit.WalletID)
-	}
-
 	if credit.Balance != "" {
 		if _, err := m.GetBalance(ctx, credit.WalletID, credit.Balance); err != nil {
 			return err

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
+	"github.com/formancehq/ledger/pkg/accounts"
 	"github.com/pkg/errors"
 )
 
@@ -282,6 +283,10 @@ func (m *Manager) VoidHold(ctx context.Context, ik string, void VoidHold) error 
 func (m *Manager) Credit(ctx context.Context, ik string, credit Credit) error {
 	if err := credit.Validate(); err != nil {
 		return err
+	}
+
+	if !accounts.ValidateAddress(credit.WalletID) {
+		return newErrInvalidAccountName(credit.WalletID)
 	}
 
 	if credit.Balance != "" {

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
-	"github.com/formancehq/ledger/pkg/accounts"
 	"github.com/pkg/errors"
 )
 
@@ -285,7 +284,7 @@ func (m *Manager) Credit(ctx context.Context, ik string, credit Credit) error {
 		return err
 	}
 
-	if !accounts.ValidateAddress(credit.WalletID) {
+	if !accountSegmentRegexp.MatchString(credit.WalletID) {
 		return newErrInvalidAccountName(credit.WalletID)
 	}
 

--- a/pkg/subject.go
+++ b/pkg/subject.go
@@ -54,8 +54,9 @@ func (s Subject) Validate() error {
 		if !accountSegmentRegexp.MatchString(s.Identifier) {
 			return newErrInvalidAccountName(s.Identifier)
 		}
-		// Balance names are stricter than wallet identifiers because
-		// Address.String() strips dashes globally, creating aliases.
+		// Balance names use the same single-segment charset as wallet
+		// identifiers (dashes allowed). Both remain subject to the
+		// dash-aliasing collision documented on Address.String().
 		if s.Balance != "" && !balanceNameRegex.MatchString(s.Balance) {
 			return newErrInvalidAccountName(s.Balance)
 		}

--- a/pkg/subject.go
+++ b/pkg/subject.go
@@ -43,6 +43,12 @@ func (s Subject) Validate() error {
 		if s.Identifier == "" {
 			return fmt.Errorf("wallet identifier cannot be empty")
 		}
+		if !accounts.ValidateAddress(s.Identifier) {
+			return newErrInvalidAccountName(s.Identifier)
+		}
+		if s.Balance != "" && !accounts.ValidateAddress(s.Balance) {
+			return newErrInvalidAccountName(s.Balance)
+		}
 	}
 	return nil
 }

--- a/pkg/subject.go
+++ b/pkg/subject.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/formancehq/ledger/pkg/accounts"
 )
@@ -10,6 +11,13 @@ const (
 	SubjectTypeLedgerAccount string = "ACCOUNT"
 	SubjectTypeWallet        string = "WALLET"
 )
+
+// accountSegmentRegexp matches a single ledger account segment (no ':'
+// separator), anchored. WALLET identifiers and balance names are used as
+// individual chart segments, so — unlike a full ledger address — they must
+// not contain ':' (which would resolve to a nested account outside the
+// expected balance model and is the Numscript-injection vector).
+var accountSegmentRegexp = regexp.MustCompile("^" + accounts.SegmentRegex + "$")
 
 type Subject struct {
 	Type       string `json:"type"`
@@ -43,10 +51,12 @@ func (s Subject) Validate() error {
 		if s.Identifier == "" {
 			return fmt.Errorf("wallet identifier cannot be empty")
 		}
-		if !accounts.ValidateAddress(s.Identifier) {
+		if !accountSegmentRegexp.MatchString(s.Identifier) {
 			return newErrInvalidAccountName(s.Identifier)
 		}
-		if s.Balance != "" && !accounts.ValidateAddress(s.Balance) {
+		// The balance is a single chart segment too, so apply the same
+		// single-segment rule (rejecting ':' and any Numscript metacharacter).
+		if s.Balance != "" && !accountSegmentRegexp.MatchString(s.Balance) {
 			return newErrInvalidAccountName(s.Balance)
 		}
 	}

--- a/pkg/subject.go
+++ b/pkg/subject.go
@@ -54,9 +54,9 @@ func (s Subject) Validate() error {
 		if !accountSegmentRegexp.MatchString(s.Identifier) {
 			return newErrInvalidAccountName(s.Identifier)
 		}
-		// The balance is a single chart segment too, so apply the same
-		// single-segment rule (rejecting ':' and any Numscript metacharacter).
-		if s.Balance != "" && !accountSegmentRegexp.MatchString(s.Balance) {
+		// Balance names are stricter than wallet identifiers because
+		// Address.String() strips dashes globally, creating aliases.
+		if s.Balance != "" && !balanceNameRegex.MatchString(s.Balance) {
 			return newErrInvalidAccountName(s.Balance)
 		}
 	}


### PR DESCRIPTION
## Problem (Critical + High — C1, H2)

The credit/debit Numscript templates interpolate account names **directly into the script body** (`@{{ .source }}`). But:
- `type:"WALLET"` subjects only checked `Identifier != ""` (neither the content nor `Balance` was validated);
- `balanceNameRegex` was **unanchored** (`[0-9A-Za-z_-]+`), so `MatchString` accepted any string containing *at least one* valid character (e.g. `balance:injected`, `x\n@world`).

An `identifier`/`balance`/balance-name containing a newline and Numscript tokens could close the `source` block and inject arbitrary statements executed with the service's ledger credentials (e.g. `send [USD *] (source = @world destination = @attacker:main)`).

## Fix

- Anchor `balanceNameRegex` → `^[0-9A-Za-z_-]+$` (a name must be a single clean segment).
- Validate both the `identifier` and `balance` of WALLET subjects via `accounts.ValidateAddress` (the same guarantee the already-safe ACCOUNT branch relies on).
- Validate `walletID` before building debit/credit scripts.

Possible follow-up defense-in-depth: bind sources as `account $sourceN` variables instead of interpolating them — left out here to avoid destabilizing the exact-Numscript assertions in the existing tests.

## Tests

- `TestBalancesCreate`: names with an account separator and with whitespace + Numscript tokens → 400.
- `TestWalletsCredit`: injection via the `balance` and via the `identifier` of a WALLET subject → 400.

From the in-depth repository review.