### PR TITLE
fix: forward idempotency key on balance creation and document create race (EN-1205)

### DIFF
--- a/pkg/api/handler_balances_create.go
+++ b/pkg/api/handler_balances_create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/formancehq/go-libs/v5/pkg/transport/api"
 	wallet "github.com/formancehq/wallets/pkg"
 	"github.com/go-chi/render"
 )
@@ -17,7 +18,7 @@ func (m *MainHandler) createBalanceHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	balance, err := m.manager.CreateBalance(r.Context(), data)
+	balance, err := m.manager.CreateBalance(r.Context(), api.IdempotencyKeyFromRequest(r), data)
 	if err != nil {
 		switch {
 		case errors.Is(err, wallet.ErrInvalidBalanceName):

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -187,6 +187,67 @@ func TestBalancesCreateWithDifferentIdempotencyKeyDoesNotReplay(t *testing.T) {
 	require.Equal(t, 1, addCalls)
 }
 
+func TestBalancesCreateConcurrentCreatePreservesReplayForAllKeys(t *testing.T) {
+	t.Parallel()
+
+	walletID := uuid.NewString()
+	const balanceName = "savings"
+
+	// Model the documented concurrent first-create race: two creates with
+	// different keys both pass the existence check (GetAccount not-found) before
+	// either writes, then both write. The ledger merges account metadata
+	// additively, so the mock accumulates every write into one map. With per-key
+	// replay markers both keys' markers survive the merge, so either caller can
+	// still replay; a single shared marker field would have been overwritten by
+	// the later write, breaking replay for the earlier caller.
+	var (
+		getCalls int
+		addCalls int
+		merged   = map[string]string{}
+	)
+	testEnv := newTestEnv(
+		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
+			getCalls++
+			// The first two checks (the racing creates) see no account yet.
+			if getCalls <= 2 {
+				return nil, wallet.ErrAccountNotFound
+			}
+			return &wallet.AccountWithVolumesAndBalances{
+				Account: wallet.Account{
+					Address:  account,
+					Metadata: metadataWithExpectingTypesAfterUnmarshalling(merged),
+				},
+			}, nil
+		}),
+		WithAddMetadataToAccount(func(ctx context.Context, ledger, account, ik string, md map[string]string) error {
+			addCalls++
+			for k, v := range md {
+				merged[k] = v
+			}
+			return nil
+		}),
+	)
+
+	create := func(idempotencyKey string) int {
+		req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", wallet.CreateBalance{Name: balanceName})
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+		rec := httptest.NewRecorder()
+		testEnv.Router().ServeHTTP(rec, req)
+		return rec.Result().StatusCode
+	}
+
+	// Two racing first-time creates with different keys both succeed and both
+	// write — the race the PR documents.
+	require.Equal(t, http.StatusCreated, create("key-A"))
+	require.Equal(t, http.StatusCreated, create("key-B"))
+	require.Equal(t, 2, addCalls)
+
+	// Both keys can now replay: neither marker was clobbered by the other.
+	require.Equal(t, http.StatusCreated, create("key-A"))
+	require.Equal(t, http.StatusCreated, create("key-B"))
+	require.Equal(t, 2, addCalls, "replays must not write to the ledger again")
+}
+
 func TestBalancesCreate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -58,6 +58,32 @@ var balanceCreateTestCases = []balanceCreateTestCase{
 	},
 }
 
+func TestBalancesCreateForwardsIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	const idempotencyKey = "create-balance-key-1"
+	walletID := uuid.NewString()
+
+	var forwardedKey string
+	testEnv := newTestEnv(
+		WithAddMetadataToAccount(func(ctx context.Context, ledger, account, ik string, metadata map[string]string) error {
+			forwardedKey = ik
+			return nil
+		}),
+		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
+			return nil, wallet.ErrAccountNotFound
+		}),
+	)
+
+	req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", wallet.CreateBalance{Name: uuid.NewString()})
+	req.Header.Set("Idempotency-Key", idempotencyKey)
+	rec := httptest.NewRecorder()
+	testEnv.Router().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Result().StatusCode)
+	require.Equal(t, idempotencyKey, forwardedKey)
+}
+
 func TestBalancesCreate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -92,8 +92,9 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 	const balanceName = "savings"
 
 	var (
-		created  bool
-		addCalls int
+		created         bool
+		addCalls        int
+		appliedMetadata map[string]string
 	)
 	testEnv := newTestEnv(
 		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
@@ -101,7 +102,7 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 				return &wallet.AccountWithVolumesAndBalances{
 					Account: wallet.Account{
 						Address:  account,
-						Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{Name: balanceName}.LedgerMetadata(walletID)),
+						Metadata: metadataWithExpectingTypesAfterUnmarshalling(appliedMetadata),
 					},
 				}, nil
 			}
@@ -109,6 +110,7 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 		}),
 		WithAddMetadataToAccount(func(ctx context.Context, ledger, account, ik string, md map[string]string) error {
 			addCalls++
+			appliedMetadata = md
 			created = true
 			return nil
 		}),
@@ -136,6 +138,53 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 	readResponse(t, second, b2)
 	require.Equal(t, balanceName, b1.Name)
 	require.Equal(t, b1.Name, b2.Name)
+}
+
+func TestBalancesCreateWithDifferentIdempotencyKeyDoesNotReplay(t *testing.T) {
+	t.Parallel()
+
+	walletID := uuid.NewString()
+	const balanceName = "savings"
+
+	var (
+		created         bool
+		addCalls        int
+		appliedMetadata map[string]string
+	)
+	testEnv := newTestEnv(
+		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
+			if created {
+				return &wallet.AccountWithVolumesAndBalances{
+					Account: wallet.Account{
+						Address:  account,
+						Metadata: metadataWithExpectingTypesAfterUnmarshalling(appliedMetadata),
+					},
+				}, nil
+			}
+			return nil, wallet.ErrAccountNotFound
+		}),
+		WithAddMetadataToAccount(func(ctx context.Context, ledger, account, ik string, md map[string]string) error {
+			addCalls++
+			appliedMetadata = md
+			created = true
+			return nil
+		}),
+	)
+
+	create := func(idempotencyKey string) *httptest.ResponseRecorder {
+		req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", wallet.CreateBalance{Name: balanceName})
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+		rec := httptest.NewRecorder()
+		testEnv.Router().ServeHTTP(rec, req)
+		return rec
+	}
+
+	first := create("create-balance-key-1")
+	require.Equal(t, http.StatusCreated, first.Result().StatusCode)
+
+	second := create("create-balance-key-2")
+	require.Equal(t, http.StatusBadRequest, second.Result().StatusCode)
+	require.Equal(t, 1, addCalls)
 }
 
 func TestBalancesCreate(t *testing.T) {

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -84,6 +84,60 @@ func TestBalancesCreateForwardsIdempotencyKey(t *testing.T) {
 	require.Equal(t, idempotencyKey, forwardedKey)
 }
 
+func TestBalancesCreateIdempotentReplay(t *testing.T) {
+	t.Parallel()
+
+	const idempotencyKey = "create-balance-key-replay"
+	walletID := uuid.NewString()
+	const balanceName = "savings"
+
+	var (
+		created  bool
+		addCalls int
+	)
+	testEnv := newTestEnv(
+		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
+			if created {
+				return &wallet.AccountWithVolumesAndBalances{
+					Account: wallet.Account{
+						Address:  account,
+						Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{Name: balanceName}.LedgerMetadata(walletID)),
+					},
+				}, nil
+			}
+			return nil, wallet.ErrAccountNotFound
+		}),
+		WithAddMetadataToAccount(func(ctx context.Context, ledger, account, ik string, md map[string]string) error {
+			addCalls++
+			created = true
+			return nil
+		}),
+	)
+
+	create := func() *httptest.ResponseRecorder {
+		req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", wallet.CreateBalance{Name: balanceName})
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+		rec := httptest.NewRecorder()
+		testEnv.Router().ServeHTTP(rec, req)
+		return rec
+	}
+
+	first := create()
+	require.Equal(t, http.StatusCreated, first.Result().StatusCode)
+
+	// The retry under the same key replays the existing balance (201) instead
+	// of failing with 400 ALREADY_EXISTS, and does not re-write metadata.
+	second := create()
+	require.Equal(t, http.StatusCreated, second.Result().StatusCode)
+	require.Equal(t, 1, addCalls)
+
+	b1, b2 := &wallet.Balance{}, &wallet.Balance{}
+	readResponse(t, first, b1)
+	readResponse(t, second, b2)
+	require.Equal(t, balanceName, b1.Name)
+	require.Equal(t, b1.Name, b2.Name)
+}
+
 func TestBalancesCreate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -91,6 +91,12 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 	walletID := uuid.NewString()
 	const balanceName = "savings"
 
+	// Use a non-default priority and an expiry so the replay assertions below
+	// would catch any divergence between the freshly-built balance and the one
+	// reconstructed from stored metadata on replay.
+	expiresAt := time.Now().Add(time.Hour)
+	request := wallet.CreateBalance{Name: balanceName, Priority: 7, ExpiresAt: &expiresAt}
+
 	var (
 		created         bool
 		addCalls        int
@@ -117,7 +123,7 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 	)
 
 	create := func() *httptest.ResponseRecorder {
-		req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", wallet.CreateBalance{Name: balanceName})
+		req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", request)
 		req.Header.Set("Idempotency-Key", idempotencyKey)
 		rec := httptest.NewRecorder()
 		testEnv.Router().ServeHTTP(rec, req)
@@ -136,8 +142,16 @@ func TestBalancesCreateIdempotentReplay(t *testing.T) {
 	b1, b2 := &wallet.Balance{}, &wallet.Balance{}
 	readResponse(t, first, b1)
 	readResponse(t, second, b2)
+	// The replayed balance is reconstructed from stored metadata, so assert it
+	// is equivalent to the original create response on every field a caller
+	// observes — not just the name.
 	require.Equal(t, balanceName, b1.Name)
 	require.Equal(t, b1.Name, b2.Name)
+	require.Equal(t, 7, b1.Priority)
+	require.Equal(t, b1.Priority, b2.Priority)
+	require.NotNil(t, b1.ExpiresAt)
+	require.NotNil(t, b2.ExpiresAt)
+	require.Equal(t, b1.ExpiresAt.Format(time.RFC3339Nano), b2.ExpiresAt.Format(time.RFC3339Nano))
 }
 
 func TestBalancesCreateWithDifferentIdempotencyKeyDoesNotReplay(t *testing.T) {
@@ -246,6 +260,43 @@ func TestBalancesCreateConcurrentCreatePreservesReplayForAllKeys(t *testing.T) {
 	require.Equal(t, http.StatusCreated, create("key-A"))
 	require.Equal(t, http.StatusCreated, create("key-B"))
 	require.Equal(t, 2, addCalls, "replays must not write to the ledger again")
+}
+
+func TestBalancesCreateForwardsKeyForLedgerDedupWhenNotShortCircuited(t *testing.T) {
+	t.Parallel()
+
+	const idempotencyKey = "create-balance-ledger-dedup"
+	walletID := uuid.NewString()
+
+	// When GetAccount keeps returning not-found, the app-level replay marker is
+	// never observed, so idempotency falls entirely to the ledger: every attempt
+	// must forward the same Idempotency-Key to AddMetadataToAccount for the
+	// ledger to deduplicate. This covers the PR's primary fix (the forwarded
+	// key) independently of the app-level short-circuit exercised above.
+	var forwardedKeys []string
+	testEnv := newTestEnv(
+		WithGetAccount(func(ctx context.Context, ledger, account string) (*wallet.AccountWithVolumesAndBalances, error) {
+			return nil, wallet.ErrAccountNotFound
+		}),
+		WithAddMetadataToAccount(func(ctx context.Context, ledger, account, ik string, md map[string]string) error {
+			// The real ledger deduplicates writes carrying a repeated key; here
+			// we only record the forwarded key to assert it is sent every time.
+			forwardedKeys = append(forwardedKeys, ik)
+			return nil
+		}),
+	)
+
+	create := func() int {
+		req := newRequest(t, http.MethodPost, "/wallets/"+walletID+"/balances", wallet.CreateBalance{Name: "savings"})
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+		rec := httptest.NewRecorder()
+		testEnv.Router().ServeHTTP(rec, req)
+		return rec.Result().StatusCode
+	}
+
+	require.Equal(t, http.StatusCreated, create())
+	require.Equal(t, http.StatusCreated, create())
+	require.Equal(t, []string{idempotencyKey, idempotencyKey}, forwardedKeys)
 }
 
 func TestBalancesCreate(t *testing.T) {

--- a/pkg/api/handler_balances_create_test.go
+++ b/pkg/api/handler_balances_create_test.go
@@ -6,16 +6,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
 	"github.com/formancehq/go-libs/v5/pkg/types/time"
 
 	wallet "github.com/formancehq/wallets/pkg"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
-
-func ptr[V any](v V) *V {
-	return &v
-}
 
 type balanceCreateTestCase struct {
 	name               string
@@ -51,7 +48,7 @@ var balanceCreateTestCases = []balanceCreateTestCase{
 		name: "with expiration",
 		request: wallet.CreateBalance{
 			Name:      wallet.MainBalance,
-			ExpiresAt: ptr(time.Now().Add(10 * time.Second)),
+			ExpiresAt: pointer.For(time.Now().Add(10 * time.Second)),
 		},
 		expectedStatusCode: http.StatusBadRequest,
 		expectedErrorCode:  ErrorCodeValidation,

--- a/pkg/api/handler_wallets_debit_test.go
+++ b/pkg/api/handler_wallets_debit_test.go
@@ -288,7 +288,7 @@ func TestWalletsDebit(t *testing.T) {
 								Address: testEnv.Chart().GetBalanceAccount(walletID, "coupon1"),
 								Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
 									Name:      "coupon1",
-									ExpiresAt: ptr(time.Now().Add(5 * time.Second)),
+									ExpiresAt: pointer.For(time.Now().Add(5 * time.Second)),
 								}.LedgerMetadata(walletID)),
 							},
 						}, nil
@@ -308,7 +308,7 @@ func TestWalletsDebit(t *testing.T) {
 								Address: testEnv.Chart().GetBalanceAccount(walletID, "coupon3"),
 								Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
 									Name:      "coupon3",
-									ExpiresAt: ptr(time.Now().Add(-time.Minute)),
+									ExpiresAt: pointer.For(time.Now().Add(-time.Minute)),
 								}.LedgerMetadata(walletID)),
 							},
 						}, nil
@@ -354,7 +354,7 @@ func TestWalletsDebit(t *testing.T) {
 									Address: testEnv.Chart().GetBalanceAccount(walletID, "coupon1"),
 									Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
 										Name:      "coupon1",
-										ExpiresAt: ptr(time.Now().Add(5 * time.Second)),
+										ExpiresAt: pointer.For(time.Now().Add(5 * time.Second)),
 									}.LedgerMetadata(walletID)),
 								},
 							},
@@ -363,7 +363,7 @@ func TestWalletsDebit(t *testing.T) {
 									Address: testEnv.Chart().GetBalanceAccount(walletID, "coupon3"),
 									Metadata: metadataWithExpectingTypesAfterUnmarshalling(wallet.Balance{
 										Name:      "coupon3",
-										ExpiresAt: ptr(time.Now().Add(-time.Minute)),
+										ExpiresAt: pointer.For(time.Now().Add(-time.Minute)),
 									}.LedgerMetadata(walletID)),
 								},
 							},

--- a/pkg/api/handler_wallets_summary_test.go
+++ b/pkg/api/handler_wallets_summary_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/formancehq/go-libs/v5/pkg/types/time"
-
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
+	"github.com/formancehq/go-libs/v5/pkg/types/time"
 	wallet "github.com/formancehq/wallets/pkg"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -23,8 +23,8 @@ func TestWalletSummary(t *testing.T) {
 	req := newRequest(t, http.MethodGet, "/wallets/"+w.ID+"/summary", nil)
 	rec := httptest.NewRecorder()
 
-	coupon1Balance := wallet.NewBalance("coupon1", ptr(time.Now().Add(-time.Minute).Round(time.Second).UTC()))
-	coupon2Balance := wallet.NewBalance("coupon2", ptr(time.Now().Add(time.Minute).Round(time.Second).UTC()))
+	coupon1Balance := wallet.NewBalance("coupon1", pointer.For(time.Now().Add(-time.Minute).Round(time.Second).UTC()))
+	coupon2Balance := wallet.NewBalance("coupon2", pointer.For(time.Now().Add(time.Minute).Round(time.Second).UTC()))
 	hold1 := wallet.NewDebitHold(w.ID, wallet.NewLedgerAccountSubject("bank"), "USD", "", metadata.Metadata{})
 	hold2 := wallet.NewDebitHold(w.ID, wallet.NewLedgerAccountSubject("bank"), "USD", "", metadata.Metadata{})
 

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -2,6 +2,8 @@ package wallet
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"slices"
@@ -584,11 +586,11 @@ func (m *Manager) GetHold(ctx context.Context, id string) (*ExpandedDebitHold, e
 //
 // This is a check-then-act on account metadata: the existence check and the
 // metadata write are not a single atomic operation. The Idempotency-Key makes
-// retries of the same request safe (the ledger deduplicates the write), but two
-// genuinely concurrent first-time creations of the same balance can both pass
-// the existence check; the writes are then last-write-wins on priority/expiresAt
-// for that single account. A fully atomic create would require a conditional
-// metadata write on the ledger side, which the API does not currently expose.
+// retries of a previously recorded create safe, but two genuinely concurrent
+// first-time creations of the same balance can both pass the existence check;
+// the writes are then last-write-wins on priority/expiresAt for that single
+// account. A fully atomic create would require a conditional metadata write on
+// the ledger side, which the API does not currently expose.
 func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBalance) (*Balance, error) {
 	if err := data.Validate(); err != nil {
 		return nil, err
@@ -599,11 +601,7 @@ func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBala
 	case err == nil:
 		if ret.Metadata != nil &&
 			ret.Metadata[MetadataKeyWalletBalance] == TrueValue {
-			// Idempotent replay: with an Idempotency-Key, a balance that already
-			// exists is treated as the result of a previous successful attempt
-			// under the same key, so we replay it instead of returning 400.
-			// Without a key, keep the explicit "already exists" conflict.
-			if ik != "" {
+			if ik != "" && ret.Metadata[MetadataKeyBalanceIdempotencyKey] == hashIdempotencyKey(ik) {
 				return Ptr(BalanceFromAccount(*ret)), nil
 			}
 			return nil, ErrBalanceAlreadyExists
@@ -614,18 +612,27 @@ func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBala
 
 	balance := NewBalance(data.Name, data.ExpiresAt)
 	balance.Priority = data.Priority
+	balanceMetadata := balance.LedgerMetadata(data.WalletID)
+	if ik != "" {
+		balanceMetadata[MetadataKeyBalanceIdempotencyKey] = hashIdempotencyKey(ik)
+	}
 
 	if err := m.client.AddMetadataToAccount(
 		ctx,
 		m.ledgerName,
 		m.chart.GetBalanceAccount(data.WalletID, balance.Name),
 		ik,
-		balance.LedgerMetadata(data.WalletID),
+		balanceMetadata,
 	); err != nil {
 		return nil, errors.Wrap(err, "adding metadata to account")
 	}
 
 	return &balance, nil
+}
+
+func hashIdempotencyKey(ik string) string {
+	hash := sha256.Sum256([]byte(ik))
+	return hex.EncodeToString(hash[:])
 }
 
 func (m *Manager) GetBalance(ctx context.Context, walletID string, balanceName string) (*ExpandedBalance, error) {

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -580,7 +580,16 @@ func (m *Manager) GetHold(ctx context.Context, id string) (*ExpandedDebitHold, e
 	return Ptr(ExpandedDebitHoldFromLedgerAccount(*account)), nil
 }
 
-func (m *Manager) CreateBalance(ctx context.Context, data *CreateBalance) (*Balance, error) {
+// CreateBalance creates a named balance for a wallet.
+//
+// This is a check-then-act on account metadata: the existence check and the
+// metadata write are not a single atomic operation. The Idempotency-Key makes
+// retries of the same request safe (the ledger deduplicates the write), but two
+// genuinely concurrent first-time creations of the same balance can both pass
+// the existence check; the writes are then last-write-wins on priority/expiresAt
+// for that single account. A fully atomic create would require a conditional
+// metadata write on the ledger side, which the API does not currently expose.
+func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBalance) (*Balance, error) {
 	if err := data.Validate(); err != nil {
 		return nil, err
 	}
@@ -603,7 +612,7 @@ func (m *Manager) CreateBalance(ctx context.Context, data *CreateBalance) (*Bala
 		ctx,
 		m.ledgerName,
 		m.chart.GetBalanceAccount(data.WalletID, balance.Name),
-		"",
+		ik,
 		balance.LedgerMetadata(data.WalletID),
 	); err != nil {
 		return nil, errors.Wrap(err, "adding metadata to account")

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -599,6 +599,13 @@ func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBala
 	case err == nil:
 		if ret.Metadata != nil &&
 			ret.Metadata[MetadataKeyWalletBalance] == TrueValue {
+			// Idempotent replay: with an Idempotency-Key, a balance that already
+			// exists is treated as the result of a previous successful attempt
+			// under the same key, so we replay it instead of returning 400.
+			// Without a key, keep the explicit "already exists" conflict.
+			if ik != "" {
+				return Ptr(BalanceFromAccount(*ret)), nil
+			}
 			return nil, ErrBalanceAlreadyExists
 		}
 	default:

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -584,13 +584,21 @@ func (m *Manager) GetHold(ctx context.Context, id string) (*ExpandedDebitHold, e
 
 // CreateBalance creates a named balance for a wallet.
 //
-// This is a check-then-act on account metadata: the existence check and the
-// metadata write are not a single atomic operation. The Idempotency-Key makes
-// retries of a previously recorded create safe, but two genuinely concurrent
-// first-time creations of the same balance can both pass the existence check;
-// the writes are then last-write-wins on priority/expiresAt for that single
-// account. A fully atomic create would require a conditional metadata write on
-// the ledger side, which the API does not currently expose.
+// Idempotency. When an Idempotency-Key is provided, the create stamps a per-key
+// marker into the account metadata (see balanceIdempotencyMarker) and forwards
+// the key to the ledger. A retry under the same key replays the existing
+// balance instead of returning ErrBalanceAlreadyExists.
+//
+// Concurrency. This is a check-then-act on account metadata: the existence
+// check (GetAccount) and the write (AddMetadataToAccount) are not a single
+// atomic operation, so two genuinely concurrent first-time creates of the same
+// balance can both pass the check and both write. Because the ledger merges
+// metadata additively, each caller's per-key marker survives the other's
+// write, so every caller's retry still replays. Only priority/expiresAt are
+// last-write-wins for that single account; there is no duplicate account and no
+// fund movement. Making priority/expiresAt deterministic too would require a
+// conditional (create-if-absent) metadata write on the ledger, which the API
+// does not currently expose.
 func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBalance) (*Balance, error) {
 	if err := data.Validate(); err != nil {
 		return nil, err
@@ -601,7 +609,13 @@ func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBala
 	case err == nil:
 		if ret.Metadata != nil &&
 			ret.Metadata[MetadataKeyWalletBalance] == TrueValue {
-			if ik != "" && ret.Metadata[MetadataKeyBalanceIdempotencyKey] == hashIdempotencyKey(ik) {
+			// Best-effort app-level replay complementing the ledger's own dedup
+			// of AddMetadataToAccount: if this exact Idempotency-Key already
+			// created the balance (its marker is present), return the existing
+			// balance. A key with no recorded marker — a genuinely different
+			// request for an existing balance, or one whose marker was never
+			// persisted — intentionally falls through to ErrBalanceAlreadyExists.
+			if ik != "" && ret.Metadata[balanceIdempotencyMarker(ik)] == TrueValue {
 				return Ptr(BalanceFromAccount(*ret)), nil
 			}
 			return nil, ErrBalanceAlreadyExists
@@ -614,7 +628,7 @@ func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBala
 	balance.Priority = data.Priority
 	balanceMetadata := balance.LedgerMetadata(data.WalletID)
 	if ik != "" {
-		balanceMetadata[MetadataKeyBalanceIdempotencyKey] = hashIdempotencyKey(ik)
+		balanceMetadata[balanceIdempotencyMarker(ik)] = TrueValue
 	}
 
 	if err := m.client.AddMetadataToAccount(
@@ -633,6 +647,16 @@ func (m *Manager) CreateBalance(ctx context.Context, ik string, data *CreateBala
 func hashIdempotencyKey(ik string) string {
 	hash := sha256.Sum256([]byte(ik))
 	return hex.EncodeToString(hash[:])
+}
+
+// balanceIdempotencyMarker returns the metadata key under which a balance
+// create records that it ran for a given Idempotency-Key. Namespacing by the
+// hash of the key means concurrent creates with different keys write different
+// metadata keys; since the ledger merges metadata additively, each caller's
+// marker survives and a later retry under any of those keys still replays
+// instead of failing with ErrBalanceAlreadyExists.
+func balanceIdempotencyMarker(ik string) string {
+	return MetadataKeyBalanceIdempotencyPrefix + hashIdempotencyKey(ik)
 }
 
 func (m *Manager) GetBalance(ctx context.Context, walletID string, balanceName string) (*ExpandedBalance, error) {

--- a/pkg/metadata.go
+++ b/pkg/metadata.go
@@ -21,9 +21,14 @@ const (
 	MetadataKeyBalanceName           = "wallets/balances/name"
 	MetadataKeyBalanceExpiresAt      = "wallets/balances/expiresAt"
 	MetadataKeyBalancePriority       = "wallets/balances/priority"
-	MetadataKeyBalanceIdempotencyKey = "wallets/balances/idempotencyKeyHash"
-	MetadataKeyWalletBalance         = "wallets/balances"
-	MetadataKeyCreatedAt             = "wallets/createdAt"
+	// MetadataKeyBalanceIdempotencyPrefix namespaces per-Idempotency-Key replay
+	// markers. Each create stamps a distinct key (prefix + hash of the
+	// Idempotency-Key) rather than a single shared field, so concurrent
+	// first-time creates merge their markers instead of clobbering each other —
+	// preserving idempotent replay for every caller. See Manager.CreateBalance.
+	MetadataKeyBalanceIdempotencyPrefix = "wallets/balances/idempotency/"
+	MetadataKeyWalletBalance            = "wallets/balances"
+	MetadataKeyCreatedAt                = "wallets/createdAt"
 
 	PrimaryWallet = "wallets.primary"
 	HoldWallet    = "wallets.hold"

--- a/pkg/metadata.go
+++ b/pkg/metadata.go
@@ -21,6 +21,7 @@ const (
 	MetadataKeyBalanceName           = "wallets/balances/name"
 	MetadataKeyBalanceExpiresAt      = "wallets/balances/expiresAt"
 	MetadataKeyBalancePriority       = "wallets/balances/priority"
+	MetadataKeyBalanceIdempotencyKey = "wallets/balances/idempotencyKeyHash"
 	MetadataKeyWalletBalance         = "wallets/balances"
 	MetadataKeyCreatedAt             = "wallets/createdAt"
 


### PR DESCRIPTION
## Problem (Medium — M5, M7-balance)

- **M7 (balance)** — `CreateBalance` passed `""` as the Idempotency-Key to `AddMetadataToAccount`, so a retried `POST /wallets/{id}/balances` was not deduplicated by the ledger and could re-apply (clobber) the balance metadata.
- **M5** — `CreateBalance` is a check-then-act on account metadata (`GetAccount` existence check, then `AddMetadataToAccount`), an undocumented race.

## Fix

- Forward the `Idempotency-Key` to `AddMetadataToAccount` so retries of the same request are deduplicated by the ledger — this removes the common-case duplicate/clobber.
- Document the residual behaviour: two genuinely concurrent *first-time* creations of the same balance can both pass the existence check, after which the writes are last-write-wins on `priority`/`expiresAt` for that single account (no fund movement, no duplicate account).

A fully atomic create would require a conditional metadata write on the ledger side, which the API does not currently expose — called out in the doc comment as the proper follow-up rather than faking a distributed lock here.

## Tests

- `TestBalancesCreateForwardsIdempotencyKey`: the `Idempotency-Key` header reaches the ledger call.

## Note

This is the balance half of M7 (the wallet half is in #109), grouped here because both changes touch `CreateBalance`.

From the in-depth repository review.