### PR TITLE
fix: update CODEOWNERS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @formancehq/backend
+* @formancehq/transactions


### PR DESCRIPTION
## What changed

- replace the retired `@formancehq/backend` CODEOWNER with `@formancehq/transactions`

## Why

The former `backend` team no longer exists. Wallets is part of the transactions domain and the `transactions` team inherits organization-wide write access through `engineer`, making it a valid and focused CODEOWNER.

## Impact

Pull requests touching this repository will request review from the current transactions team once CODEOWNER reviews are enforced.

## Validation

- confirmed the `transactions` team exists
- confirmed the team inherits the `all_repo_write` organization role
- `git diff --check`
- verified that only `CODEOWNERS` changed
