### PR TITLE
chore: transfer code ownership to the connectivity team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @formancehq/transactions
+* @formancehq/connectivity


### PR DESCRIPTION
## Summary
- Update the root `CODEOWNERS` so all files are owned by `@formancehq/connectivity` instead of `@formancehq/transactions`.

Note: the org has no `payments` team — `connectivity` was chosen as the requested owner.

## Test plan
- [x] `@formancehq/connectivity` team exists in the org (verified via `gh api orgs/formancehq/teams`)
- [ ] GitHub requests review from the connectivity team on the next PR touching the repo