### PR TITLE
fix(audit): make HTTP audit opt-in instead of enabled by default

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,7 +82,7 @@ func newServeCommand() *cobra.Command {
 	cmd.Flags().String(LedgerNameFlag, "wallets-002", "Target ledger")
 	cmd.Flags().String(AccountPrefixFlag, "", "Account prefix flag")
 	cmd.Flags().String(ListenFlag, ":8080", "Listen address")
-	cmd.Flags().Bool(audit.AuditEnabledFlag, true, "Enable HTTP audit")
+	cmd.Flags().Bool(audit.AuditEnabledFlag, false, "Enable HTTP audit")
 
 	service.AddFlags(cmd.Flags())
 	licence.AddFlags(cmd.Flags())

--- a/cmd/serve_audit_test.go
+++ b/cmd/serve_audit_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/formancehq/go-libs/v5/pkg/audit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditDefaultsToDisabled(t *testing.T) {
+	cmd := newServeCommand()
+
+	enabled, err := cmd.Flags().GetBool(audit.AuditEnabledFlag)
+	require.NoError(t, err)
+	require.False(t, enabled, "HTTP audit must stay opt-in")
+}


### PR DESCRIPTION
## Problem

`--audit-enabled` defaults to `true`, and **the operator never passes this flag** to module deployments — I grepped `formancehq/operator` for `audit-enabled` / `AuditEnabled` and there is no match. The compiled-in default is therefore what runs in production, so the HTTP audit middleware is active without anyone having explicitly turned it on.

## Why opt-in is the right default

The audit middleware shipped in go-libs `#604` and needed four follow-up fixes (`#610` async publishing, `#620`/EN-1152 handled-header secret, `#647` body capping, `#656` query params). One gap is still open in practice: `#620` makes a shared secret *available*, but **no service in the stack configures one**, so the `audit-handled` dedup header remains spoofable — any client can set it and skip the audit trail.

Audit should be a deliberate deployment decision rather than something that happens by default while that is unresolved.

## Change

One-line default flip plus a regression test pinning it. This aligns with:

- `go-libs`' own `audit.AddFlags`, which defaults `audit-enabled` to `false`
- `webhooks`, which already defaults to `false` (`TestAuditEnabledDefaultsToFalse`)
- `auth`, being aligned in formancehq/auth#149

## Impact

**No production impact.** The deployed wallets version is v2.1.5 (June 2025), which predates the audit middleware entirely — this only affects unreleased `main`, ahead of the v2.2.0 release.

## Validation

- `go build ./...` — clean
- `go test -count=1 ./cmd/...` — pass, including the new `TestAuditDefaultsToDisabled`

https://claude.ai/code/session_01Tb7rgNz6hGo2wGBTmymPL1